### PR TITLE
Fix MCQ option parsing: use `;;` separator + drop `&apos;`/`&gt;`/`&lt;` entities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ci:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +59,15 @@ jobs:
         with:
           path: docs/_site
 
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/_includes/quiz.html
+++ b/docs/_includes/quiz.html
@@ -4,18 +4,21 @@ Reusable MCQ quiz question.
 Usage (in a markdown page):
   {% include quiz.html id="atom-1"
      question="What defines an atom in Atomic Design?"
-     options="A|Manages its own state;B|Has a single responsibility and cannot be decomposed further;C|Always renders a button element;D|Contains at least three child components"
+     options="A|Manages its own state;;B|Has a single responsibility and cannot be decomposed further;;C|Always renders a button element;;D|Contains at least three child components"
      correct="B"
      explanation="Atoms are the smallest functional units—single-purpose components that cannot be broken down without losing meaning." %}
 
 Required params:
   id          — a page-unique slug used for the radio group name and aria ids.
   question    — the prompt (plain text; HTML allowed).
-  options     — semicolon-separated list of "letter|text" pairs (letters A/B/C/D/E …).
+  options     — `;;`-separated list of "letter|text" pairs (letters A/B/C/D/E …).
+                `;;` is used instead of a single `;` so option text can safely
+                contain HTML entities (`&quot;`, `&amp;`, `&lt;`, `&gt;`) and
+                natural-language semicolons without breaking the split.
   correct     — the letter of the correct option.
   explanation — markdown/plain-text shown after submit (HTML allowed).
 {%- endcomment -%}
-{%- assign _opts = include.options | split: ';' -%}
+{%- assign _opts = include.options | split: ';;' -%}
 <form class="quiz-mcq" data-correct="{{ include.correct }}" novalidate>
   <p class="quiz-mcq__question"><strong>{{ include.question }}</strong></p>
   <ul class="quiz-mcq__options" role="radiogroup" aria-labelledby="quiz-{{ include.id }}-q">

--- a/docs/server/api.md
+++ b/docs/server/api.md
@@ -611,31 +611,31 @@ A two-way interactive communication session between the user’s browser and a s
 
 {% include quiz.html id="api-1"
    question="What is the primary purpose of request and response interceptors in an API client?"
-   options="A|To log every request;B|To centralise cross-cutting concerns — attaching auth tokens, logging, transforming payloads, handling errors, refreshing tokens — so individual call sites stay clean and consistent;C|To disable HTTP/2;D|To replace the fetch API"
+   options="A|To log every request;;B|To centralise cross-cutting concerns — attaching auth tokens, logging, transforming payloads, handling errors, refreshing tokens — so individual call sites stay clean and consistent;;C|To disable HTTP/2;;D|To replace the fetch API"
    correct="B"
    explanation="Interceptors are the one place that knows about auth headers, retry logic, error normalisation — the rest of the codebase just calls api.get/api.post." %}
 
 {% include quiz.html id="api-2"
    question="Which HTTP method should be used for which REST operation?"
-   options="A|GET for everything;B|GET to read (safe, idempotent), POST to create (not idempotent), PUT to replace (idempotent), PATCH to partially update, DELETE to remove (idempotent);C|POST for reads;D|DELETE for updates"
+   options="A|GET for everything;;B|GET to read (safe, idempotent), POST to create (not idempotent), PUT to replace (idempotent), PATCH to partially update, DELETE to remove (idempotent);;C|POST for reads;;D|DELETE for updates"
    correct="B"
    explanation="Respecting method semantics makes APIs predictable, cacheable, and safe to retry. GET/PUT/DELETE are idempotent — safe to retry — POST is not." %}
 
 {% include quiz.html id="api-3"
    question="Should API services contain business logic and application state?"
-   options="A|Yes — keep everything in one place;B|No — API services should be thin, pure data-transport clients. Business logic and application state belong in the state layer (Redux/Saga/NgRx/Pinia). Keeping them separate makes the API layer reusable across stores and testable in isolation;C|Only for GraphQL;D|Only Redux can wrap APIs"
+   options="A|Yes — keep everything in one place;;B|No — API services should be thin, pure data-transport clients. Business logic and application state belong in the state layer (Redux/Saga/NgRx/Pinia). Keeping them separate makes the API layer reusable across stores and testable in isolation;;C|Only for GraphQL;;D|Only Redux can wrap APIs"
    correct="B"
    explanation="When the API client is pure, swapping state management, testing with fakes, or reusing the client in a different app are all trivial." %}
 
 {% include quiz.html id="api-4"
    question="What's the safest way to store and attach auth tokens client-side?"
-   options="A|localStorage with a long expiry;B|Prefer httpOnly, Secure, SameSite cookies for session tokens so JS can't read them (mitigating XSS). If you must use memory/storage, keep short-lived access tokens in memory and use a rotating refresh token via an httpOnly cookie. Always use HTTPS;C|Put tokens in the URL;D|In a global variable on window"
+   options="A|localStorage with a long expiry;;B|Prefer httpOnly, Secure, SameSite cookies for session tokens so JS can't read them (mitigating XSS). If you must use memory/storage, keep short-lived access tokens in memory and use a rotating refresh token via an httpOnly cookie. Always use HTTPS;;C|Put tokens in the URL;;D|In a global variable on window"
    correct="B"
    explanation="localStorage is XSS-readable; cookies with httpOnly+Secure+SameSite are the defence-in-depth default. Token rotation limits blast radius if one leaks." %}
 
 {% include quiz.html id="api-5"
    question="How do REST, GraphQL, and WebSocket differ?"
-   options="A|They are the same protocol;B|REST is resource-oriented HTTP with multiple endpoints; GraphQL is a single endpoint where the client specifies exactly the fields it needs (reduces over-fetching/under-fetching); WebSocket is a persistent bidirectional connection for real-time pushes (chat, live updates). Pick per use case — they often coexist;C|GraphQL has replaced REST;D|WebSockets only work in Node"
+   options="A|They are the same protocol;;B|REST is resource-oriented HTTP with multiple endpoints; GraphQL is a single endpoint where the client specifies exactly the fields it needs (reduces over-fetching/under-fetching); WebSocket is a persistent bidirectional connection for real-time pushes (chat, live updates). Pick per use case — they often coexist;;C|GraphQL has replaced REST;;D|WebSockets only work in Node"
    correct="B"
    explanation="REST wins for simple CRUD and cacheability, GraphQL for complex client-driven data needs, WebSockets (or SSE) for push — most large apps mix all three." %}
 

--- a/docs/server/app-shell.md
+++ b/docs/server/app-shell.md
@@ -870,19 +870,19 @@ function Shell() {
 
 {% include quiz.html id="app-shell-1"
    question="What is the App Shell architecture and when should you choose it over a traditional multi-page app?"
-   options="A|App Shell = a minimal HTML/CSS/JS shell cached aggressively (often by a service worker) with content loaded dynamically after. It shines for dashboards, SaaS, and mobile-first apps where users navigate frequently; an MPA with SSR is usually better for SEO-critical content sites;B|It always beats MPA;C|It is only for iOS;D|It disables caching"
+   options="A|App Shell = a minimal HTML/CSS/JS shell cached aggressively (often by a service worker) with content loaded dynamically after. It shines for dashboards, SaaS, and mobile-first apps where users navigate frequently; an MPA with SSR is usually better for SEO-critical content sites;;B|It always beats MPA;;C|It is only for iOS;;D|It disables caching"
    correct="A"
    explanation="Use App Shell when repeated navigation cost matters more than first-paint SEO. Use MPA/SSR when search-engine discoverability of every page is paramount." %}
 
 {% include quiz.html id="app-shell-2"
    question="What is progressive hydration and what does it solve?"
-   options="A|Hydrating all components on DOMContentLoaded;B|Hydrating components in priority order as they become visible or idle, so TTI isn't blocked by a huge synchronous hydration pass over every component on every page load;C|Disabling hydration entirely;D|A Vue-only feature"
+   options="A|Hydrating all components on DOMContentLoaded;;B|Hydrating components in priority order as they become visible or idle, so TTI isn't blocked by a huge synchronous hydration pass over every component on every page load;;C|Disabling hydration entirely;;D|A Vue-only feature"
    correct="B"
    explanation="Naive hydration ties up the main thread and delays interactivity. Progressive hydration (islands, lazy boundaries, requestIdleCallback) spreads that work out." %}
 
 {% include quiz.html id="app-shell-3"
    question="Why do providers (theme, auth, router, store) live at the App Shell level in a micro-frontend setup?"
-   options="A|So each MFE ships its own provider copies;B|To establish shared context and services ONCE at the shell boundary, so the individual micro-frontends share theme/auth/router/store without each bundling their own and fighting over state;C|Providers are optional at the shell level;D|They don't — providers are per-MFE"
+   options="A|So each MFE ships its own provider copies;;B|To establish shared context and services ONCE at the shell boundary, so the individual micro-frontends share theme/auth/router/store without each bundling their own and fighting over state;;C|Providers are optional at the shell level;;D|They don't — providers are per-MFE"
    correct="B"
    explanation="Elevating providers to the shell keeps the MFEs loosely coupled and avoids state or theme duplication when multiple MFEs render on the same page." %}
 

--- a/docs/server/authentication.md
+++ b/docs/server/authentication.md
@@ -1004,31 +1004,31 @@ If enabled, users will be prompted for an additional form of authentication, suc
 
 {% include quiz.html id="authentication-1"
    question="Where should a JWT access token be stored on the client?"
-   options="A|localStorage with a long expiry;B|In memory (variable or short-lived cache) with a rotating refresh token in an httpOnly, Secure, SameSite cookie — localStorage is readable by any XSS-injected script, which is a critical token exfiltration vector;C|Hardcoded in a data attribute;D|In the URL hash"
+   options="A|localStorage with a long expiry;;B|In memory (variable or short-lived cache) with a rotating refresh token in an httpOnly, Secure, SameSite cookie — localStorage is readable by any XSS-injected script, which is a critical token exfiltration vector;;C|Hardcoded in a data attribute;;D|In the URL hash"
    correct="B"
    explanation="Memory + httpOnly refresh cookie is the defence-in-depth default. A stored access token is as good as compromised the moment XSS lands." %}
 
 {% include quiz.html id="authentication-2"
    question="How do you implement silent token refresh without logging users out mid-session?"
-   options="A|Ask the user to re-log in whenever the token expires;B|When the API returns 401, an interceptor pauses in-flight requests, calls the refresh endpoint (using a refresh token in an httpOnly cookie), swaps in the new access token, and retries the queued requests — transparent to the UI;C|Poll the refresh endpoint every second;D|Never expire tokens"
+   options="A|Ask the user to re-log in whenever the token expires;;B|When the API returns 401, an interceptor pauses in-flight requests, calls the refresh endpoint (using a refresh token in an httpOnly cookie), swaps in the new access token, and retries the queued requests — transparent to the UI;;C|Poll the refresh endpoint every second;;D|Never expire tokens"
    correct="B"
    explanation="Coalescing in-flight requests during refresh avoids stampedes, and the httpOnly refresh cookie means JS never touches the long-lived secret." %}
 
 {% include quiz.html id="authentication-3"
    question="What's the cleanest way to protect routes in a React app?"
-   options="A|Check auth in every page component individually;B|Wrap protected routes in a ProtectedRoute / RequireAuth component (or a layout route) that reads auth state and redirects to /login when unauthenticated, preserving the intended destination so the user lands back there after signing in;C|Use window.location everywhere;D|Redirect in useEffect on every page"
+   options="A|Check auth in every page component individually;;B|Wrap protected routes in a ProtectedRoute / RequireAuth component (or a layout route) that reads auth state and redirects to /login when unauthenticated, preserving the intended destination so the user lands back there after signing in;;C|Use window.location everywhere;;D|Redirect in useEffect on every page"
    correct="B"
    explanation="A route-level guard keeps auth logic in one spot, handles return-to-URL cleanly, and composes with role-based guards for authorization." %}
 
 {% include quiz.html id="authentication-4"
    question="What is the difference between authentication and authorization?"
-   options="A|They are synonyms;B|Authentication answers &quot;who are you?&quot; (login, MFA, SSO); authorization answers &quot;what are you allowed to do?&quot; (roles, permissions, ACLs). You need the first before you can meaningfully enforce the second;C|Authorization happens first;D|Authorization is a UI concern only"
+   options="A|They are synonyms;;B|Authentication answers &quot;who are you?&quot; (login, MFA, SSO); authorization answers &quot;what are you allowed to do?&quot; (roles, permissions, ACLs). You need the first before you can meaningfully enforce the second;;C|Authorization happens first;;D|Authorization is a UI concern only"
    correct="B"
    explanation="AuthN proves identity; AuthZ enforces policy. Many security bugs come from conflating the two or from checking only one at the wrong layer." %}
 
 {% include quiz.html id="authentication-5"
    question="Which of these is NOT a standard production hardening for auth?"
-   options="A|HTTPS everywhere and Secure+SameSite+httpOnly cookies;B|Short-lived access tokens with rotating refresh tokens;C|Rate-limiting login and refresh endpoints, plus MFA for sensitive actions;D|Logging plaintext passwords in audit trails so you can debug"
+   options="A|HTTPS everywhere and Secure+SameSite+httpOnly cookies;;B|Short-lived access tokens with rotating refresh tokens;;C|Rate-limiting login and refresh endpoints, plus MFA for sensitive actions;;D|Logging plaintext passwords in audit trails so you can debug"
    correct="D"
    explanation="Never log plaintext credentials — it turns every log aggregator into a secondary credentials breach risk. A/B/C are the usual defence-in-depth stack." %}
 

--- a/docs/server/container.md
+++ b/docs/server/container.md
@@ -783,31 +783,31 @@ function ProductCard({ product, onAddToCart }) {
 
 {% include quiz.html id="container-1"
    question="What's the main difference between a container component and a presentational component?"
-   options="A|Containers render UI, presentational components fetch data;B|Containers own data/state concerns (subscribing to a store, fetching, orchestrating dispatch); presentational components take data via props and render UI. The split keeps UI reusable and testable;C|They're the same thing;D|Containers only exist in Angular"
+   options="A|Containers render UI, presentational components fetch data;;B|Containers own data/state concerns (subscribing to a store, fetching, orchestrating dispatch); presentational components take data via props and render UI. The split keeps UI reusable and testable;;C|They're the same thing;;D|Containers only exist in Angular"
    correct="B"
    explanation="The &quot;smart vs dumb&quot; split lets the UI layer be prop-driven and portable, while the container wires state + side effects in one place." %}
 
 {% include quiz.html id="container-2"
    question="How do React hooks (useSelector, useDispatch, useQuery) change the classic container pattern?"
-   options="A|They eliminate the need for containers entirely;B|They blur the container/presentational line — you can co-locate store access inside a component via hooks. The atomic-design discipline is still useful: keep low-level atoms/molecules pure and put hooks in a wrapper (the &quot;container&quot;) so the UI stays framework- and store-agnostic;C|They only work with MobX;D|Hooks make containers mandatory"
+   options="A|They eliminate the need for containers entirely;;B|They blur the container/presentational line — you can co-locate store access inside a component via hooks. The atomic-design discipline is still useful: keep low-level atoms/molecules pure and put hooks in a wrapper (the &quot;container&quot;) so the UI stays framework- and store-agnostic;;C|They only work with MobX;;D|Hooks make containers mandatory"
    correct="B"
    explanation="Hooks don't remove the pattern, they make it cheaper. A small hook-using wrapper around a presentational component is still a container; it just doesn't need connect()." %}
 
 {% include quiz.html id="container-3"
    question="When would you reach for a Redux-connected container vs a custom hook?"
-   options="A|Redux containers are always better;B|Use a custom hook when one slice of state is consumed locally by one or two components; use a Redux container (or useSelector in a container component) when multiple containers share the same derived data, memoized via selectors, to avoid duplicating subscriptions and re-renders;C|Custom hooks are deprecated;D|It's purely stylistic"
+   options="A|Redux containers are always better;;B|Use a custom hook when one slice of state is consumed locally by one or two components; use a Redux container (or useSelector in a container component) when multiple containers share the same derived data, memoized via selectors, to avoid duplicating subscriptions and re-renders;;C|Custom hooks are deprecated;;D|It's purely stylistic"
    correct="B"
    explanation="Custom hooks are great for colocation; selectors-in-a-container shine when the derivation is shared and expensive." %}
 
 {% include quiz.html id="container-4"
    question="How should you test a container vs a presentational component?"
-   options="A|Only snapshot-test both;B|Test presentational components by passing props and asserting on the rendered DOM or events; test containers by providing a mocked store / data layer and asserting that the right actions are dispatched or the right selectors used. Many teams mostly integration-test containers and unit-test presentational components;C|Never test containers;D|Tests are irrelevant"
+   options="A|Only snapshot-test both;;B|Test presentational components by passing props and asserting on the rendered DOM or events; test containers by providing a mocked store / data layer and asserting that the right actions are dispatched or the right selectors used. Many teams mostly integration-test containers and unit-test presentational components;;C|Never test containers;;D|Tests are irrelevant"
    correct="B"
    explanation="Keeping the two layers separate makes the presentational tests fast and pure, and the container tests focused on wiring and side effects." %}
 
 {% include quiz.html id="container-5"
    question="How do containers interact with Storybook?"
-   options="A|Containers go in Storybook too with a real production store;B|Storybook usually renders the PRESENTATIONAL component with handcrafted props — sometimes wrapping in decorators that provide a mock Redux/Pinia/NgRx store or Router so a container can be shown in isolation without the real backend. Containers shine in tests, presentationals shine in Storybook;C|Storybook doesn't support state-management decorators;D|You must disable Storybook for container components"
+   options="A|Containers go in Storybook too with a real production store;;B|Storybook usually renders the PRESENTATIONAL component with handcrafted props — sometimes wrapping in decorators that provide a mock Redux/Pinia/NgRx store or Router so a container can be shown in isolation without the real backend. Containers shine in tests, presentationals shine in Storybook;;C|Storybook doesn't support state-management decorators;;D|You must disable Storybook for container components"
    correct="B"
    explanation="Presentational components take props, which Storybook's Controls can drive directly. Containers, if shown at all, get mock context via decorators." %}
 

--- a/docs/server/forms.md
+++ b/docs/server/forms.md
@@ -1020,31 +1020,31 @@ function RegistrationForm() {
 
 {% include quiz.html id="forms-1"
    question="What's the difference between a controlled and an uncontrolled component in React?"
-   options="A|Controlled components manage their own state internally; uncontrolled receive it via props;B|Controlled components drive the input value from React state (onChange updates state which drives value); uncontrolled components let the DOM hold the value and you read it via ref. Controlled gives fine-grained validation/formatting; uncontrolled has less re-render overhead;C|They are the same;D|Uncontrolled is deprecated"
+   options="A|Controlled components manage their own state internally; uncontrolled receive it via props;;B|Controlled components drive the input value from React state (onChange updates state which drives value); uncontrolled components let the DOM hold the value and you read it via ref. Controlled gives fine-grained validation/formatting; uncontrolled has less re-render overhead;;C|They are the same;;D|Uncontrolled is deprecated"
    correct="B"
    explanation="Controlled = React is the single source of truth. Uncontrolled = the DOM is. Controlled is the default for most forms; uncontrolled shines for large/perf-sensitive forms via libraries like React Hook Form." %}
 
 {% include quiz.html id="forms-2"
    question="What's the most robust client-side validation strategy?"
-   options="A|Only inline onChange checks;B|Validate on blur for per-field feedback, on submit for the whole form, surface errors via aria-describedby/role=alert, and ALWAYS re-validate on the server — client validation is UX, not security;C|Rely only on HTML5 required/pattern;D|Validate only after submit"
+   options="A|Only inline onChange checks;;B|Validate on blur for per-field feedback, on submit for the whole form, surface errors via aria-describedby/role=alert, and ALWAYS re-validate on the server — client validation is UX, not security;;C|Rely only on HTML5 required/pattern;;D|Validate only after submit"
    correct="B"
    explanation="On-blur + on-submit gives the best UX (no noisy errors while typing, clear errors at the moment of intent). Server-side validation is non-negotiable because anyone can bypass the client." %}
 
 {% include quiz.html id="forms-3"
    question="How do you implement async validation (e.g. &quot;is this username taken?&quot;) without hammering the server?"
-   options="A|Fire a request on every keystroke;B|Debounce user input (e.g. 300ms), cancel in-flight requests when the value changes, show a pending state in the UI, and require a final server check on submit;C|Disable the input until submit;D|Only validate on form submit"
+   options="A|Fire a request on every keystroke;;B|Debounce user input (e.g. 300ms), cancel in-flight requests when the value changes, show a pending state in the UI, and require a final server check on submit;;C|Disable the input until submit;;D|Only validate on form submit"
    correct="B"
    explanation="Debounce + abortable fetch prevents request storms and race conditions where an old response overwrites a newer result. Always gate the final action on the server's response." %}
 
 {% include quiz.html id="forms-4"
    question="How should you build a multi-step form?"
-   options="A|Put every field on one page and hide with CSS;B|Model it as a state machine with per-step validation, keep form data in a single parent (lifted state or form-library store), persist progress to localStorage or a draft endpoint so refresh doesn't lose data, and provide clear progress indication + back navigation;C|Submit each step separately;D|Use multiple &lt;form&gt; elements without shared state"
+   options="A|Put every field on one page and hide with CSS;;B|Model it as a state machine with per-step validation, keep form data in a single parent (lifted state or form-library store), persist progress to localStorage or a draft endpoint so refresh doesn't lose data, and provide clear progress indication + back navigation;;C|Submit each step separately;;D|Use multiple <form> elements without shared state"
    correct="B"
    explanation="A single source of truth for the data + step-level validation + draft persistence is the pattern that scales from 3-step sign-ups to 20-step onboarding." %}
 
 {% include quiz.html id="forms-5"
    question="When should you use a form library (React Hook Form, Formik) vs rolling your own?"
-   options="A|Always roll your own for full control;B|For a 2-3 field form, custom is fine and cheaper; for anything with conditional fields, dynamic arrays, async/cross-field validation, or accessibility rigor, a library pays back quickly. React Hook Form is often chosen for performance (uncontrolled under the hood);C|Form libraries are obsolete;D|Only use libraries in Angular"
+   options="A|Always roll your own for full control;;B|For a 2-3 field form, custom is fine and cheaper; for anything with conditional fields, dynamic arrays, async/cross-field validation, or accessibility rigor, a library pays back quickly. React Hook Form is often chosen for performance (uncontrolled under the hood);;C|Form libraries are obsolete;;D|Only use libraries in Angular"
    correct="B"
    explanation="Don't reach for a library reflexively, but don't reinvent validation, field arrays, and accessibility on every project either. The crossover point is typically around 5 fields or any conditional logic." %}
 

--- a/docs/server/images.md
+++ b/docs/server/images.md
@@ -789,32 +789,32 @@ function AspectRatioImage({ src, alt, aspectRatio = '16/9' }) {
 ## Quick Quiz
 
 {% include quiz.html id="images-1"
-   question="What's the difference between srcset and sizes on an &lt;img&gt;?"
-   options="A|They're synonyms;B|srcset lists candidate image URLs with their intrinsic widths (w) or pixel densities (x); sizes tells the browser how wide the image will actually be rendered at different breakpoints so it can pick the best srcset candidate. Both are needed for responsive resolution switching;C|sizes only affects the aspect ratio;D|srcset is for retina only"
+   question="What's the difference between srcset and sizes on an <img>?"
+   options="A|They're synonyms;;B|srcset lists candidate image URLs with their intrinsic widths (w) or pixel densities (x); sizes tells the browser how wide the image will actually be rendered at different breakpoints so it can pick the best srcset candidate. Both are needed for responsive resolution switching;;C|sizes only affects the aspect ratio;;D|srcset is for retina only"
    correct="B"
    explanation="Without sizes, the browser assumes 100vw and picks a larger image than needed. Give it both (srcset=&quot;a.jpg 480w, b.jpg 1200w&quot; + sizes=&quot;(max-width: 768px) 100vw, 50vw&quot;) for optimal downloads." %}
 
 {% include quiz.html id="images-2"
    question="How do you implement progressive image loading with a blur placeholder?"
-   options="A|Preload the full-resolution image;B|Inline a tiny base64 blurred thumbnail (LQIP) as src or background, then swap to the full image once loaded and fade/unblur via CSS — or use the native blur-up technique frameworks like Next/Image / Gatsby-image provide out of the box;C|Use only a loading spinner;D|Lazy-loading alone"
+   options="A|Preload the full-resolution image;;B|Inline a tiny base64 blurred thumbnail (LQIP) as src or background, then swap to the full image once loaded and fade/unblur via CSS — or use the native blur-up technique frameworks like Next/Image / Gatsby-image provide out of the box;;C|Use only a loading spinner;;D|Lazy-loading alone"
    correct="B"
    explanation="LQIP + blur fade gives an instant visual placeholder that smoothly resolves into the full image once it arrives, improving perceived performance and LCP stability." %}
 
 {% include quiz.html id="images-3"
-   question="When should you use &lt;picture&gt; vs &lt;img srcset&gt;?"
-   options="A|They are interchangeable;B|Use srcset+sizes for resolution switching (same image, different sizes). Use &lt;picture&gt; with &lt;source&gt; for art direction or format fallbacks — different crops per breakpoint, or WebP/AVIF with a JPEG fallback;C|&lt;picture&gt; is deprecated;D|&lt;picture&gt; only works in Safari"
+   question="When should you use <picture> vs <img srcset>?"
+   options="A|They are interchangeable;;B|Use srcset+sizes for resolution switching (same image, different sizes). Use <picture> with <source> for art direction or format fallbacks — different crops per breakpoint, or WebP/AVIF with a JPEG fallback;;C|<picture> is deprecated;;D|<picture> only works in Safari"
    correct="B"
-   explanation="srcset = size switching. &lt;picture&gt; = change image, crop, or format. You often combine them: &lt;picture&gt; with WebP/AVIF sources + a &lt;img srcset&gt; fallback." %}
+   explanation="srcset = size switching. <picture> = change image, crop, or format. You often combine them: <picture> with WebP/AVIF sources + a <img srcset> fallback." %}
 
 {% include quiz.html id="images-4"
    question="How should you optimise images for Core Web Vitals (especially LCP and CLS)?"
-   options="A|Add more animations;B|Set explicit width/height (or CSS aspect-ratio) to prevent CLS; mark the LCP hero image with fetchpriority=&quot;high&quot; and preload it; lazy-load below-the-fold images (loading=&quot;lazy&quot;); serve AVIF/WebP via &lt;picture&gt;; use srcset+sizes for correct downloads;C|Always lazy-load the hero image;D|Inline every image as base64"
+   options="A|Add more animations;;B|Set explicit width/height (or CSS aspect-ratio) to prevent CLS; mark the LCP hero image with fetchpriority=&quot;high&quot; and preload it; lazy-load below-the-fold images (loading=&quot;lazy&quot;); serve AVIF/WebP via <picture>; use srcset+sizes for correct downloads;;C|Always lazy-load the hero image;;D|Inline every image as base64"
    correct="B"
    explanation="Explicit dimensions prevent layout shift, priority hints accelerate the LCP image, lazy-loading saves bandwidth below the fold, and modern formats cut bytes dramatically." %}
 
 {% include quiz.html id="images-5"
    question="How do image CDNs help automate optimisation?"
-   options="A|They only cache JPEGs;B|They transform images on demand — resizing, reformatting to WebP/AVIF via Accept headers, compressing, and serving from edge caches — so you ship one source asset and the CDN delivers the right size/format per request. Many also add DPR-aware URLs and client-hint integration;C|They only work in enterprise;D|They disable caching"
+   options="A|They only cache JPEGs;;B|They transform images on demand — resizing, reformatting to WebP/AVIF via Accept headers, compressing, and serving from edge caches — so you ship one source asset and the CDN delivers the right size/format per request. Many also add DPR-aware URLs and client-hint integration;;C|They only work in enterprise;;D|They disable caching"
    correct="B"
    explanation="Cloudinary, Imgix, imagekit, and the CDN arms of Cloudflare/Vercel/Netlify all do content-aware transformation at the edge so you don't hand-generate 12 size variants per image." %}
 

--- a/docs/server/localization.md
+++ b/docs/server/localization.md
@@ -660,31 +660,31 @@ function ItemCount({ count }) {
 
 {% include quiz.html id="localization-1"
    question="What is the difference between i18n (internationalization) and L10n (localization)?"
-   options="A|They are the same term;B|i18n is the one-time engineering work of making a product capable of being localised (extracting strings, locale-aware formatting, RTL support, bidi-safe layouts). L10n is the per-locale work of actually translating content and adapting it culturally. i18n is the platform, L10n is the payload;C|L10n comes first;D|Only i18n applies to React apps"
+   options="A|They are the same term;;B|i18n is the one-time engineering work of making a product capable of being localised (extracting strings, locale-aware formatting, RTL support, bidi-safe layouts). L10n is the per-locale work of actually translating content and adapting it culturally. i18n is the platform, L10n is the payload;;C|L10n comes first;;D|Only i18n applies to React apps"
    correct="B"
    explanation="Get i18n right once and adding a new locale (L10n) is mostly translation + QA. Skip i18n and every locale requires new engineering." %}
 
 {% include quiz.html id="localization-2"
    question="Why can't you just use &quot;{n} items&quot; for pluralisation?"
-   options="A|You can — English and French work the same way;B|Languages have different plural categories (English: one/other; Russian: one/few/many/other; Arabic: zero/one/two/few/many/other). Use a CLDR-driven API like Intl.PluralRules or an i18n library's plural syntax — hand-rolling breaks most non-English locales;C|Pluralisation is deprecated;D|JavaScript can't count"
+   options="A|You can — English and French work the same way;;B|Languages have different plural categories (English: one/other; Russian: one/few/many/other; Arabic: zero/one/two/few/many/other). Use a CLDR-driven API like Intl.PluralRules or an i18n library's plural syntax — hand-rolling breaks most non-English locales;;C|Pluralisation is deprecated;;D|JavaScript can't count"
    correct="B"
    explanation="Intl.PluralRules (or ICU MessageFormat via i18next/FormatJS) knows each language's categories. &quot;1 item / 2 items&quot; is an English assumption most of the world doesn't share." %}
 
 {% include quiz.html id="localization-3"
    question="Which URL strategy is best for SEO of localised content?"
-   options="A|Query string (?lang=fr) — Google treats these as the same URL;B|Subdirectory (/fr/...) or subdomain (fr.example.com) with hreflang link tags telling search engines which locale each page is for — give each localised page a stable, crawlable URL;C|Cookie-only, so all locales share one URL;D|JavaScript redirects"
+   options="A|Query string (?lang=fr) — Google treats these as the same URL;;B|Subdirectory (/fr/...) or subdomain (fr.example.com) with hreflang link tags telling search engines which locale each page is for — give each localised page a stable, crawlable URL;;C|Cookie-only, so all locales share one URL;;D|JavaScript redirects"
    correct="B"
    explanation="Cookie/query-based switches give search engines nothing to index per locale. Stable URL + hreflang is the standard recommendation from Google's i18n docs." %}
 
 {% include quiz.html id="localization-4"
    question="What does RTL (right-to-left) language support require beyond translation?"
-   options="A|Only translating strings;B|Setting dir=&quot;rtl&quot; on the root, using logical CSS properties (margin-inline-start, padding-inline-end, text-align: start) so layout mirrors correctly, auditing icons/arrows for directionality, and handling mixed-direction text with bidi controls where needed;C|Using a bigger font;D|Reversing the JavaScript array"
+   options="A|Only translating strings;;B|Setting dir=&quot;rtl&quot; on the root, using logical CSS properties (margin-inline-start, padding-inline-end, text-align: start) so layout mirrors correctly, auditing icons/arrows for directionality, and handling mixed-direction text with bidi controls where needed;;C|Using a bigger font;;D|Reversing the JavaScript array"
    correct="B"
    explanation="CSS logical properties flip automatically with dir=&quot;rtl&quot;. Physical properties (left/right, margin-left) don't — they're the source of most RTL bugs." %}
 
 {% include quiz.html id="localization-5"
    question="How do you keep i18n from bloating the bundle?"
-   options="A|Ship every locale's JSON in the main bundle;B|Load only the active locale's messages (dynamic import by locale code), lazy-load additional locales on language switch, split messages per route where possible, and consider server-side locale negotiation so you never ship other-locale text to the client at all;C|Inline all translations as strings;D|Use one giant JSON for every language"
+   options="A|Ship every locale's JSON in the main bundle;;B|Load only the active locale's messages (dynamic import by locale code), lazy-load additional locales on language switch, split messages per route where possible, and consider server-side locale negotiation so you never ship other-locale text to the client at all;;C|Inline all translations as strings;;D|Use one giant JSON for every language"
    correct="B"
    explanation="Locale-split bundles scale linearly per-locale instead of adding every locale's cost to every visitor. CDN-served localised JSON loaded on demand is the standard pattern." %}
 

--- a/docs/server/mfe.md
+++ b/docs/server/mfe.md
@@ -968,19 +968,19 @@ function Dashboard() {
 
 {% include quiz.html id="mfe-1"
    question="Compare Module Federation and Web Components for integrating micro-frontends. When would you pick each?"
-   options="A|They are identical;B|Module Federation (Webpack/Rspack) dynamically loads ESM at runtime and shares dependencies (React, lodash) as singletons to avoid duplication — best for teams on the same framework version aligned on shared deps. Web Components wrap each MFE as a custom element with its own internal stack — best for framework-heterogeneous teams that need strict isolation at the cost of some bundle duplication;C|Web Components are deprecated;D|Only Module Federation works in production"
+   options="A|They are identical;;B|Module Federation (Webpack/Rspack) dynamically loads ESM at runtime and shares dependencies (React, lodash) as singletons to avoid duplication — best for teams on the same framework version aligned on shared deps. Web Components wrap each MFE as a custom element with its own internal stack — best for framework-heterogeneous teams that need strict isolation at the cost of some bundle duplication;;C|Web Components are deprecated;;D|Only Module Federation works in production"
    correct="B"
    explanation="Module Federation optimises for sharing (less duplication, tighter coupling on deps). Web Components optimise for isolation (more duplication, looser coupling). Pick based on org structure and framework diversity." %}
 
 {% include quiz.html id="mfe-2"
    question="How should authentication be handled across multiple micro-frontends?"
-   options="A|Each MFE ships its own login form and token storage;B|Hoist auth to the shell — shell owns sign-in, token storage (httpOnly refresh cookie + in-memory access token), and exposes an auth context / event bus to MFEs. MFEs read the current user and react to logout broadcasts, but don&apos;t duplicate the login flow. Refresh and rotation happen once, centrally;C|Use cookies only and hope;D|Auth can&apos;t be shared"
+   options="A|Each MFE ships its own login form and token storage;;B|Hoist auth to the shell — shell owns sign-in, token storage (httpOnly refresh cookie + in-memory access token), and exposes an auth context / event bus to MFEs. MFEs read the current user and react to logout broadcasts, but don't duplicate the login flow. Refresh and rotation happen once, centrally;;C|Use cookies only and hope;;D|Auth can't be shared"
    correct="B"
    explanation="Centralising auth prevents inconsistent sessions (logged in here, out there), coordinates token refresh, and keeps the single-sign-on UX coherent across MFEs." %}
 
 {% include quiz.html id="mfe-3"
    question="How do you prevent MFE bundle bloat from killing performance?"
-   options="A|Ship every MFE at once regardless of route;B|Set per-MFE performance budgets; deduplicate shared deps via Module Federation singletons or import maps; lazy-load MFEs on route entry; preload the next likely MFE on hover/idle; audit with tools like bundlewatch / webpack-bundle-analyzer per MFE; treat an MFE&apos;s bundle size as a cross-team contract;C|Only use Web Components;D|Budgets don&apos;t matter"
+   options="A|Ship every MFE at once regardless of route;;B|Set per-MFE performance budgets; deduplicate shared deps via Module Federation singletons or import maps; lazy-load MFEs on route entry; preload the next likely MFE on hover/idle; audit with tools like bundlewatch / webpack-bundle-analyzer per MFE; treat an MFE's bundle size as a cross-team contract;;C|Only use Web Components;;D|Budgets don't matter"
    correct="B"
    explanation="Without per-MFE budgets and shared-dep deduplication, every MFE ships its own React + its own utils — bundle cost scales linearly with MFE count. Lazy loading + preloading + dedup keeps cost sub-linear." %}
 

--- a/docs/server/pwa.md
+++ b/docs/server/pwa.md
@@ -903,31 +903,31 @@ router.on('navigate', async (path) => {
 
 {% include quiz.html id="pwa-1"
    question="What are the states of a service worker's lifecycle?"
-   options="A|install -> run -> stop;B|install -> waiting -> activate -> active (and redundant if replaced or discarded). The waiting state is why new SW versions don't take over immediately — existing clients keep the old SW until it's safe to activate;C|fetch -> cache -> respond;D|new -> ready -> finished"
+   options="A|install -> run -> stop;;B|install -> waiting -> activate -> active (and redundant if replaced or discarded). The waiting state is why new SW versions don't take over immediately — existing clients keep the old SW until it's safe to activate;;C|fetch -> cache -> respond;;D|new -> ready -> finished"
    correct="B"
    explanation="Knowing the lifecycle is how you implement &quot;new version available — reload?&quot; UX correctly. skipWaiting() and clients.claim() let you force takeover, at the cost of potentially interrupting the running page." %}
 
 {% include quiz.html id="pwa-2"
    question="When should you use Cache First vs Network First caching?"
-   options="A|Cache First for everything;B|Cache First for immutable, hashed assets (JS/CSS/fonts/images) — serve instantly, update in the background (stale-while-revalidate). Network First for dynamic or time-sensitive data (API responses, user-specific content) — fall back to cache only when offline;C|Network First for all assets;D|Always go to the network and never cache"
+   options="A|Cache First for everything;;B|Cache First for immutable, hashed assets (JS/CSS/fonts/images) — serve instantly, update in the background (stale-while-revalidate). Network First for dynamic or time-sensitive data (API responses, user-specific content) — fall back to cache only when offline;;C|Network First for all assets;;D|Always go to the network and never cache"
    correct="B"
    explanation="Matching strategy to content is the whole point of a service worker. Immutable assets want Cache First; fresh data wants Network First with a cache fallback." %}
 
 {% include quiz.html id="pwa-3"
    question="What are the minimum requirements for a site to be installable as a PWA?"
-   options="A|Just a manifest.json;B|Served over HTTPS (or localhost for dev), a valid web app manifest with at least name/short_name, start_url, display (standalone/fullscreen/etc), and icons (typically 192px + 512px), plus a registered service worker;C|Only a service worker;D|A native app in the store first"
+   options="A|Just a manifest.json;;B|Served over HTTPS (or localhost for dev), a valid web app manifest with at least name/short_name, start_url, display (standalone/fullscreen/etc), and icons (typically 192px + 512px), plus a registered service worker;;C|Only a service worker;;D|A native app in the store first"
    correct="B"
    explanation="Browsers gate the install prompt on these baseline signals. Missing any one (no HTTPS, missing icons, no service worker) typically suppresses the install affordance." %}
 
 {% include quiz.html id="pwa-4"
    question="How does Background Sync help with offline form submissions?"
-   options="A|It disables the form offline;B|The page registers a sync tag when offline submission fails; the service worker listens for the 'sync' event, which the browser fires once connectivity is restored, and replays the queued request from IndexedDB. The user gets confirmation without reopening the app;C|It caches the final URL only;D|It is a server-side feature"
+   options="A|It disables the form offline;;B|The page registers a sync tag when offline submission fails; the service worker listens for the 'sync' event, which the browser fires once connectivity is restored, and replays the queued request from IndexedDB. The user gets confirmation without reopening the app;;C|It caches the final URL only;;D|It is a server-side feature"
    correct="B"
    explanation="Background Sync (via Workbox queues or a manual IndexedDB queue) turns flaky networks from &quot;lost data&quot; into &quot;deferred success&quot; without the user doing anything." %}
 
 {% include quiz.html id="pwa-5"
    question="What's the difference between the Push API and the Notifications API?"
-   options="A|They are the same thing;B|Push API delivers a message from a server to the service worker even when the app is closed (via a push service like FCM/APNS bridge + a VAPID-signed subscription). Notifications API displays a system-level notification. Push usually triggers a Notification, but each can be used without the other;C|Notifications are deprecated;D|Push only works on Android"
+   options="A|They are the same thing;;B|Push API delivers a message from a server to the service worker even when the app is closed (via a push service like FCM/APNS bridge + a VAPID-signed subscription). Notifications API displays a system-level notification. Push usually triggers a Notification, but each can be used without the other;;C|Notifications are deprecated;;D|Push only works on Android"
    correct="B"
    explanation="Push = transport (server -> SW). Notification = UI. Web push subscriptions require user permission; notifications can also be triggered from any page with the right permission." %}
 

--- a/docs/server/router.md
+++ b/docs/server/router.md
@@ -667,31 +667,31 @@ const router = createBrowserRouter([
 
 {% include quiz.html id="router-1"
    question="How does client-side routing avoid a full page reload?"
-   options="A|It disables browser history;B|The router intercepts link clicks, uses history.pushState to update the URL without reloading, and swaps the rendered view component based on the new URL — the shell, providers, and JS context stay live;C|It requires a service worker;D|It makes an AJAX call that returns a new HTML document"
+   options="A|It disables browser history;;B|The router intercepts link clicks, uses history.pushState to update the URL without reloading, and swaps the rendered view component based on the new URL — the shell, providers, and JS context stay live;;C|It requires a service worker;;D|It makes an AJAX call that returns a new HTML document"
    correct="B"
    explanation="pushState + a matching popstate listener is the core primitive every SPA router (React Router, Vue Router, @angular/router) builds on." %}
 
 {% include quiz.html id="router-2"
    question="In React Router, what's the difference between useParams, useLocation, and useNavigate?"
-   options="A|They're synonyms;B|useParams returns the dynamic segments matched by the current route (e.g. :id -&gt; { id }); useLocation returns the current Location object (pathname, search, hash, state) for reading query strings or router state; useNavigate returns an imperative fn to programmatically navigate (push/replace);C|They only work in Remix;D|useParams is server-only"
+   options="A|They're synonyms;;B|useParams returns the dynamic segments matched by the current route (e.g. :id -> { id }); useLocation returns the current Location object (pathname, search, hash, state) for reading query strings or router state; useNavigate returns an imperative fn to programmatically navigate (push/replace);;C|They only work in Remix;;D|useParams is server-only"
    correct="B"
    explanation="Params = the matched dynamic bits. Location = everything about the current URL. navigate() = the go-somewhere verb. Each is a narrow tool with one job." %}
 
 {% include quiz.html id="router-3"
    question="How do nested routes work in React Router v6+?"
-   options="A|Each route must be a sibling at the top level;B|Parent routes render an &lt;Outlet /&gt; where matched child routes render, enabling shared layout/chrome (sidebar, header) across child pages without re-mounting. Relative paths and nested route config build the tree;C|Nested routes are deprecated;D|You must use window.location"
+   options="A|Each route must be a sibling at the top level;;B|Parent routes render an <Outlet /> where matched child routes render, enabling shared layout/chrome (sidebar, header) across child pages without re-mounting. Relative paths and nested route config build the tree;;C|Nested routes are deprecated;;D|You must use window.location"
    correct="B"
    explanation="The Outlet pattern is how you implement layouts, dashboards with subpages, and auth-guarded sections that share context without each child managing its own chrome." %}
 
 {% include quiz.html id="router-4"
    question="What's the cleanest way to protect routes that require authentication?"
-   options="A|Check auth inside every page component;B|Use a layout/guard route (ProtectedRoute, RequireAuth) that checks auth state and either renders its &lt;Outlet /&gt; or redirects to /login with the intended destination saved so the user returns there after signing in;C|Intercept in server middleware only;D|Use try/catch around routes"
+   options="A|Check auth inside every page component;;B|Use a layout/guard route (ProtectedRoute, RequireAuth) that checks auth state and either renders its <Outlet /> or redirects to /login with the intended destination saved so the user returns there after signing in;;C|Intercept in server middleware only;;D|Use try/catch around routes"
    correct="B"
    explanation="A single guard layer keeps auth logic in one place, handles return-to-URL, and composes with role-based guards cleanly." %}
 
 {% include quiz.html id="router-5"
    question="How does React.lazy() + Suspense improve SPA performance with routing?"
-   options="A|It makes rendering synchronous;B|It code-splits a route's component into its own chunk so it's fetched only when that route is visited — cutting the initial bundle. Suspense boundaries show a fallback while the chunk loads. Combined with route-level preloading on hover you get lazy routes with snappy feel;C|It replaces the router;D|It only works at build time"
+   options="A|It makes rendering synchronous;;B|It code-splits a route's component into its own chunk so it's fetched only when that route is visited — cutting the initial bundle. Suspense boundaries show a fallback while the chunk loads. Combined with route-level preloading on hover you get lazy routes with snappy feel;;C|It replaces the router;;D|It only works at build time"
    correct="B"
    explanation="Per-route code splitting is one of the highest-leverage perf wins — the visitor of /home never downloads the JS for /settings." %}
 

--- a/docs/server/seo.md
+++ b/docs/server/seo.md
@@ -520,31 +520,31 @@ export default function BlogPost({ post }) {
 
 {% include quiz.html id="seo-1"
    question="What's the difference between Open Graph and Twitter Card meta tags?"
-   options="A|They are the same thing;B|Open Graph (og:*) is Facebook/LinkedIn/Discord's standard for link preview; Twitter Card (twitter:*) is Twitter/X's. Most platforms fall back to og: if twitter: is missing, so you usually set og: for everyone and add a twitter:card type to control Twitter's layout;C|Only Open Graph is real;D|They only affect SEO rankings"
+   options="A|They are the same thing;;B|Open Graph (og:*) is Facebook/LinkedIn/Discord's standard for link preview; Twitter Card (twitter:*) is Twitter/X's. Most platforms fall back to og: if twitter: is missing, so you usually set og: for everyone and add a twitter:card type to control Twitter's layout;;C|Only Open Graph is real;;D|They only affect SEO rankings"
    correct="B"
    explanation="Share previews (not ranking) are driven by these tags. Set og: as the baseline; twitter: just customises the Twitter-specific appearance." %}
 
 {% include quiz.html id="seo-2"
    question="How does JSON-LD structured data help SEO?"
-   options="A|It improves page load time;B|It describes page content in schema.org vocabulary, enabling rich results in search (stars for reviews, recipe cards, event info, product prices) — higher CTR from SERPs without changing the visible page;C|It is deprecated;D|It only works in Chrome"
+   options="A|It improves page load time;;B|It describes page content in schema.org vocabulary, enabling rich results in search (stars for reviews, recipe cards, event info, product prices) — higher CTR from SERPs without changing the visible page;;C|It is deprecated;;D|It only works in Chrome"
    correct="B"
-   explanation="Google's rich-results eligibility, Knowledge Graph, and voice-assistant answers all key off structured data. JSON-LD is the preferred format because it's non-intrusive (a &lt;script type=&quot;application/ld+json&quot;&gt; block)." %}
+   explanation="Google's rich-results eligibility, Knowledge Graph, and voice-assistant answers all key off structured data. JSON-LD is the preferred format because it's non-intrusive (a <script type=&quot;application/ld+json&quot;> block)." %}
 
 {% include quiz.html id="seo-3"
    question="Why are Core Web Vitals important for SEO?"
-   options="A|They don't affect SEO;B|Google uses them as ranking signals (LCP, CLS, INP) via the Page Experience system — slow or janky pages are penalized in competitive queries, and good vitals also improve conversion independent of ranking;C|Only LCP matters;D|They only apply to mobile"
+   options="A|They don't affect SEO;;B|Google uses them as ranking signals (LCP, CLS, INP) via the Page Experience system — slow or janky pages are penalized in competitive queries, and good vitals also improve conversion independent of ranking;;C|Only LCP matters;;D|They only apply to mobile"
    correct="B"
    explanation="CWV are an official ranking signal and, crucially, a user-experience signal that correlates with bounce rate and conversion — optimising them helps both SEO and business metrics." %}
 
 {% include quiz.html id="seo-4"
    question="When should you use a canonical tag?"
-   options="A|On every page, always pointing at itself;B|Whenever the same (or substantially similar) content is reachable at multiple URLs — e.g. with/without trailing slash, with query params like ?ref=, printable/non-printable, localised duplicates — to tell search engines which URL is the preferred one and consolidate link equity;C|Only on 404 pages;D|To hide a page from search"
+   options="A|On every page, always pointing at itself;;B|Whenever the same (or substantially similar) content is reachable at multiple URLs — e.g. with/without trailing slash, with query params like ?ref=, printable/non-printable, localised duplicates — to tell search engines which URL is the preferred one and consolidate link equity;;C|Only on 404 pages;;D|To hide a page from search"
    correct="B"
    explanation="Self-referential canonicals on every page are the common safe default, plus explicit canonicals for known duplicates. rel=&quot;canonical&quot; is a hint, not a directive, but it's widely respected." %}
 
 {% include quiz.html id="seo-5"
    question="How do you make client-side-navigated SPA pages SEO-friendly?"
-   options="A|SEO doesn't work for SPAs — accept it;B|Render the initial request server-side (SSR) or at build time (SSG) so crawlers see real HTML + real metadata. On client-side navigation, update the document title and meta tags (react-helmet-async / next/head / &lt;svelte:head&gt;) so each logical &quot;page&quot; has the right SEO metadata even though the app didn't reload;C|Render an image of the page;D|Put keywords in data- attributes"
+   options="A|SEO doesn't work for SPAs — accept it;;B|Render the initial request server-side (SSR) or at build time (SSG) so crawlers see real HTML + real metadata. On client-side navigation, update the document title and meta tags (react-helmet-async / next/head / <svelte:head>) so each logical &quot;page&quot; has the right SEO metadata even though the app didn't reload;;C|Render an image of the page;;D|Put keywords in data- attributes"
    correct="B"
    explanation="Modern crawlers execute some JS but SSR/SSG gives the best results, fastest and most reliable. Per-route head management ensures each SPA route has proper title/description/canonical." %}
 

--- a/docs/server/session.md
+++ b/docs/server/session.md
@@ -948,31 +948,31 @@ async function logout() {
 
 {% include quiz.html id="session-1"
    question="What's the purpose of having both an access token AND a refresh token?"
-   options="A|It's just historical;B|Short-lived access tokens limit the damage if one leaks; a longer-lived refresh token (stored more securely, usually in an httpOnly cookie) lets the client exchange for new access tokens without asking the user to re-log in. Separation of duties;C|Refresh tokens are deprecated;D|They are the same token"
+   options="A|It's just historical;;B|Short-lived access tokens limit the damage if one leaks; a longer-lived refresh token (stored more securely, usually in an httpOnly cookie) lets the client exchange for new access tokens without asking the user to re-log in. Separation of duties;;C|Refresh tokens are deprecated;;D|They are the same token"
    correct="B"
    explanation="Compromise an access token and the window of misuse is minutes. Compromise the refresh token and you need a different, harder attack (XSS can't read httpOnly cookies) — defence in depth." %}
 
 {% include quiz.html id="session-2"
    question="How does token rotation prevent replay attacks?"
-   options="A|By making tokens longer;B|Every refresh exchanges the current refresh token for a new one and invalidates the old one. If an attacker replays an old refresh token, the server detects the collision and can revoke the whole family — confining the compromise and forcing a genuine re-auth;C|Rotation is purely cosmetic;D|It disables token expiry"
+   options="A|By making tokens longer;;B|Every refresh exchanges the current refresh token for a new one and invalidates the old one. If an attacker replays an old refresh token, the server detects the collision and can revoke the whole family — confining the compromise and forcing a genuine re-auth;;C|Rotation is purely cosmetic;;D|It disables token expiry"
    correct="B"
    explanation="Rotation + detection of reused refresh tokens is the OAuth 2.1 recommendation. It turns a silent replay into a visible anomaly the server can respond to." %}
 
 {% include quiz.html id="session-3"
    question="What's a clean way to implement cross-tab session sync (so logging out in one tab logs out in all)?"
-   options="A|Poll localStorage every 500ms;B|Use BroadcastChannel or the 'storage' event to notify other tabs of login/logout/refresh events, and have each tab react (clear state, redirect to /login, retry requests with the new token);C|Only open one tab;D|Reload every tab on any click"
+   options="A|Poll localStorage every 500ms;;B|Use BroadcastChannel or the 'storage' event to notify other tabs of login/logout/refresh events, and have each tab react (clear state, redirect to /login, retry requests with the new token);;C|Only open one tab;;D|Reload every tab on any click"
    correct="B"
    explanation="BroadcastChannel is the modern API; the 'storage' event is a fallback for older browsers. Either way: one tab publishes session events, all tabs subscribe." %}
 
 {% include quiz.html id="session-4"
    question="What's the difference between a sliding and an absolute session timeout?"
-   options="A|They're identical;B|Sliding timeout extends the expiry on every activity (&quot;idle for 30 minutes&quot; logs you out); absolute timeout expires a session N hours after login regardless of activity — so even an active session periodically forces re-auth. Most systems combine both: sliding for idle, absolute for hard cap;C|Absolute timeout only applies server-side;D|Sliding timeout is insecure"
+   options="A|They're identical;;B|Sliding timeout extends the expiry on every activity (&quot;idle for 30 minutes&quot; logs you out); absolute timeout expires a session N hours after login regardless of activity — so even an active session periodically forces re-auth. Most systems combine both: sliding for idle, absolute for hard cap;;C|Absolute timeout only applies server-side;;D|Sliding timeout is insecure"
    correct="B"
    explanation="Sliding = user-friendly, limits idle risk. Absolute = security-friendly, caps session lifetime even for active users. Combine them for the best of both." %}
 
 {% include quiz.html id="session-5"
    question="How should you persist session state across page reloads?"
-   options="A|In-memory only, so refresh always logs the user out;B|Keep the access token (or session id) in httpOnly cookie for the server to read, or in memory with a refresh cookie that re-hydrates on boot; avoid localStorage for tokens (XSS-readable). Put non-sensitive UI state in sessionStorage;C|Put tokens in the URL;D|Only use cookies for everything"
+   options="A|In-memory only, so refresh always logs the user out;;B|Keep the access token (or session id) in httpOnly cookie for the server to read, or in memory with a refresh cookie that re-hydrates on boot; avoid localStorage for tokens (XSS-readable). Put non-sensitive UI state in sessionStorage;;C|Put tokens in the URL;;D|Only use cookies for everything"
    correct="B"
    explanation="httpOnly cookies for secrets, memory (or ephemeral store) for the access token, and sessionStorage for non-sensitive UI state is the battle-tested combo." %}
 

--- a/docs/server/ssg.md
+++ b/docs/server/ssg.md
@@ -473,31 +473,31 @@ export async function getStaticPaths() {
 
 {% include quiz.html id="ssg-1"
    question="What's the difference between SSG, SSR, and CSR?"
-   options="A|They are three names for the same thing;B|CSR renders in the browser after JS loads (slow first paint, no SEO by default); SSR renders on every request on the server (fresh data, but server cost per request); SSG renders at build time into static HTML (fast, cacheable, CDN-friendly, but stale until rebuild). Modern stacks mix all three per route;C|SSG only works in Next.js;D|SSR has been deprecated"
+   options="A|They are three names for the same thing;;B|CSR renders in the browser after JS loads (slow first paint, no SEO by default); SSR renders on every request on the server (fresh data, but server cost per request); SSG renders at build time into static HTML (fast, cacheable, CDN-friendly, but stale until rebuild). Modern stacks mix all three per route;;C|SSG only works in Next.js;;D|SSR has been deprecated"
    correct="B"
    explanation="Choose per page: product listings maybe SSR, marketing pages SSG, dashboards CSR. The big frameworks (Next, Nuxt, Astro, Remix) let you mix." %}
 
 {% include quiz.html id="ssg-2"
    question="How does Incremental Static Regeneration (ISR) work?"
-   options="A|It disables caching;B|Pages are generated at build time like SSG, but with a revalidation window; the next request after that window triggers a background regeneration — visitors get the stale page immediately while the new one is produced and cached. You get SSG speed with near-SSR freshness;C|ISR regenerates the entire site on every request;D|ISR is the same as CSR"
+   options="A|It disables caching;;B|Pages are generated at build time like SSG, but with a revalidation window; the next request after that window triggers a background regeneration — visitors get the stale page immediately while the new one is produced and cached. You get SSG speed with near-SSR freshness;;C|ISR regenerates the entire site on every request;;D|ISR is the same as CSR"
    correct="B"
    explanation="&quot;Stale-while-revalidate for pages&quot; — visitors never wait for regeneration, and content updates without a full rebuild." %}
 
 {% include quiz.html id="ssg-3"
    question="In Next.js's getStaticPaths, what do the different fallback values mean?"
-   options="A|fallback: false -> only paths returned are rendered, others 404; fallback: true -> non-listed paths render a loading state then fetch data on demand; fallback: 'blocking' -> non-listed paths render on-demand SSR-style with no loading flash;B|They're all equivalent;C|Fallback is purely cosmetic;D|Only 'false' is real"
+   options="A|fallback: false -> only paths returned are rendered, others 404; fallback: true -> non-listed paths render a loading state then fetch data on demand; fallback: 'blocking' -> non-listed paths render on-demand SSR-style with no loading flash;;B|They're all equivalent;;C|Fallback is purely cosmetic;;D|Only 'false' is real"
    correct="A"
    explanation="Pick based on the size and freshness of your path set: small/known paths = false; huge/long-tail paths = true or 'blocking' depending on UX needs." %}
 
 {% include quiz.html id="ssg-4"
    question="When should you use on-demand revalidation vs time-based ISR?"
-   options="A|Always on-demand;B|Time-based is simpler but has a lag window (stale until the next request past the timer); on-demand (e.g. a webhook from your CMS calling res.revalidate) invalidates the cached page immediately after a content change — better for editorial content where staleness is user-visible;C|On-demand requires full rebuilds;D|They can't be combined"
+   options="A|Always on-demand;;B|Time-based is simpler but has a lag window (stale until the next request past the timer); on-demand (e.g. a webhook from your CMS calling res.revalidate) invalidates the cached page immediately after a content change — better for editorial content where staleness is user-visible;;C|On-demand requires full rebuilds;;D|They can't be combined"
    correct="B"
    explanation="Use time-based as a safety net (&quot;at most N hours stale&quot;) and on-demand for immediate freshness after a real edit. Most modern setups use both." %}
 
 {% include quiz.html id="ssg-5"
    question="How do you keep build times manageable for large SSG sites?"
-   options="A|Rebuild everything on every deploy forever;B|Use ISR/on-demand generation for long-tail pages, incremental builds that only rebuild changed pages, parallel builds, a CDN with per-path invalidation, and content-hash caching for build artefacts. Avoid putting thousands of low-traffic pages into the synchronous build;C|Disable caching;D|Combine all pages into a single HTML"
+   options="A|Rebuild everything on every deploy forever;;B|Use ISR/on-demand generation for long-tail pages, incremental builds that only rebuild changed pages, parallel builds, a CDN with per-path invalidation, and content-hash caching for build artefacts. Avoid putting thousands of low-traffic pages into the synchronous build;;C|Disable caching;;D|Combine all pages into a single HTML"
    correct="B"
    explanation="The goal is: rebuild what changed, serve everything else from cache. Frameworks now do incremental builds and on-demand generation specifically so build time scales sub-linearly with site size." %}
 

--- a/docs/server/ssr.md
+++ b/docs/server/ssr.md
@@ -377,31 +377,31 @@ hydrateRoot(
 
 {% include quiz.html id="ssr-1"
    question="What's the difference between Server-Side Rendering (SSR) and Static Site Generation (SSG)?"
-   options="A|SSG renders on every request, SSR renders at build time;B|SSR renders HTML on each request on the server (fresh data, per-user); SSG pre-renders HTML at build time into static files (fast, cacheable, cheap to serve, but stale until rebuilt). ISR is the middle ground — SSG with background revalidation;C|They're identical;D|SSR only works in Node"
+   options="A|SSG renders on every request, SSR renders at build time;;B|SSR renders HTML on each request on the server (fresh data, per-user); SSG pre-renders HTML at build time into static files (fast, cacheable, cheap to serve, but stale until rebuilt). ISR is the middle ground — SSG with background revalidation;;C|They're identical;;D|SSR only works in Node"
    correct="B"
    explanation="Pick per-route: per-user personalised pages -> SSR; marketing/blog/docs -> SSG; near-real-time content -> ISR (SSG + revalidate)." %}
 
 {% include quiz.html id="ssr-2"
    question="What is hydration?"
-   options="A|Fetching data from the server;B|The process where the client-side JS &quot;takes over&quot; the server-rendered HTML: the same component tree renders on the client, attaches event handlers, and wires up state so the static markup becomes interactive;C|A type of caching;D|A lifecycle hook"
+   options="A|Fetching data from the server;;B|The process where the client-side JS &quot;takes over&quot; the server-rendered HTML: the same component tree renders on the client, attaches event handlers, and wires up state so the static markup becomes interactive;;C|A type of caching;;D|A lifecycle hook"
    correct="B"
    explanation="SSR sends HTML for fast first paint; hydration turns it into a live app. Mismatches between server and client markup (time-dependent content, locale mismatches) cause hydration errors." %}
 
 {% include quiz.html id="ssr-3"
    question="With SSR, do you still need to ship JavaScript to the client?"
-   options="A|No — SSR means zero JS;B|Yes — the server-rendered HTML is static until hydrated. Interactivity (onClick, state changes, client-side routing) requires the same React/Vue/Angular bundle to run on the client. React Server Components / partial hydration / islands reduce the JS, but don't eliminate it for interactive regions"
+   options="A|No — SSR means zero JS;;B|Yes — the server-rendered HTML is static until hydrated. Interactivity (onClick, state changes, client-side routing) requires the same React/Vue/Angular bundle to run on the client. React Server Components / partial hydration / islands reduce the JS, but don't eliminate it for interactive regions"
    correct="B"
    explanation="&quot;SSR = no JS&quot; is a common misconception. SSR + hydration = fast initial HTML AND full interactivity after JS loads. You can reduce bundle size with islands/RSC but not to zero for interactive apps." %}
 
 {% include quiz.html id="ssr-4"
    question="What are the main SEO benefits of SSR over pure client-side rendering?"
-   options="A|SSR makes your site rank higher automatically;B|The HTML returned contains actual content and metadata — crawlers (including those with limited JS execution), social link-preview bots, and tooling get real content without waiting on JS. That improves discoverability, LCP, and share-preview quality;C|SSR is the only way to get Google to index a site;D|SSR has no SEO effect"
+   options="A|SSR makes your site rank higher automatically;;B|The HTML returned contains actual content and metadata — crawlers (including those with limited JS execution), social link-preview bots, and tooling get real content without waiting on JS. That improves discoverability, LCP, and share-preview quality;;C|SSR is the only way to get Google to index a site;;D|SSR has no SEO effect"
    correct="B"
    explanation="Modern Googlebot does execute JS, but SSR still wins for robustness, speed, non-Google crawlers, and non-browser fetchers (Twitter, LinkedIn, Slack, etc.)." %}
 
 {% include quiz.html id="ssr-5"
    question="What's the purpose of renderToString vs renderToPipeableStream in React?"
-   options="A|They do the same thing;B|renderToString renders the whole tree into a single HTML string before responding — simple, but the client waits for the slowest data. renderToPipeableStream streams HTML in chunks as components resolve, unblocking TTFB and letting Suspense boundaries resolve progressively;C|renderToPipeableStream is deprecated;D|Only one works in Node"
+   options="A|They do the same thing;;B|renderToString renders the whole tree into a single HTML string before responding — simple, but the client waits for the slowest data. renderToPipeableStream streams HTML in chunks as components resolve, unblocking TTFB and letting Suspense boundaries resolve progressively;;C|renderToPipeableStream is deprecated;;D|Only one works in Node"
    correct="B"
    explanation="Streaming rendering (with Suspense) gets content to the user earlier. renderToString is still fine for small/simple pages where streaming setup isn't worth it." %}
 

--- a/docs/state/actions.md
+++ b/docs/state/actions.md
@@ -403,32 +403,32 @@ const usersSlice = createSlice({
 
 {% include quiz.html id="actions-1"
    question="What's the difference between an action type and an action creator?"
-   options="A|They are the same thing;B|An action type is a constant string that identifies what happened (&apos;todo/added&apos;, CREATE_TODO); an action creator is a function that builds and returns an action object with that type (plus payload, meta). Types keep reducers/middleware matching consistent; creators keep dispatch sites uniform;C|Types are runtime, creators are compile-time;D|Action creators are deprecated"
+   options="A|They are the same thing;;B|An action type is a constant string that identifies what happened ('todo/added', CREATE_TODO); an action creator is a function that builds and returns an action object with that type (plus payload, meta). Types keep reducers/middleware matching consistent; creators keep dispatch sites uniform;;C|Types are runtime, creators are compile-time;;D|Action creators are deprecated"
    correct="B"
    explanation="Types are the wire format. Creators encapsulate payload shaping, default fields, and any input coercion so callers just pass raw data." %}
 
 {% include quiz.html id="actions-2"
-   question="When should you reach for a thunk (or RTK&apos;s createAsyncThunk) vs a plain action creator?"
-   options="A|Always use thunks;B|Plain action creators return a bare action object (sync, pure). Thunks return a function that receives (dispatch, getState) so you can sequence async work, read state, and dispatch multiple actions — use them when an action needs to fetch, branch, or dispatch more actions. For complex async flows a saga/epic may suit better;C|Thunks are only for Angular;D|Plain action creators can&apos;t return objects"
+   question="When should you reach for a thunk (or RTK's createAsyncThunk) vs a plain action creator?"
+   options="A|Always use thunks;;B|Plain action creators return a bare action object (sync, pure). Thunks return a function that receives (dispatch, getState) so you can sequence async work, read state, and dispatch multiple actions — use them when an action needs to fetch, branch, or dispatch more actions. For complex async flows a saga/epic may suit better;;C|Thunks are only for Angular;;D|Plain action creators can't return objects"
    correct="B"
-   explanation="Thunks are the simplest way to add async to Redux. If you find thunks getting complex (cancellation, retries, race conditions) that&apos;s the signal to step up to sagas/epics or RTK Query." %}
+   explanation="Thunks are the simplest way to add async to Redux. If you find thunks getting complex (cancellation, retries, race conditions) that's the signal to step up to sagas/epics or RTK Query." %}
 
 {% include quiz.html id="actions-3"
    question="What is the Flux Standard Action (FSA) shape?"
-   options="A|{ name, data };B|{ type, payload, error?, meta? } — a consistent envelope where type identifies the action, payload carries the data, error flags failure (in which case payload is the Error), and meta holds cross-cutting info (requestId, timestamp). Keeps reducers/middleware predictable;C|{ op, args };D|Any object shape at all"
+   options="A|{ name, data };;B|{ type, payload, error?, meta? } — a consistent envelope where type identifies the action, payload carries the data, error flags failure (in which case payload is the Error), and meta holds cross-cutting info (requestId, timestamp). Keeps reducers/middleware predictable;;C|{ op, args };;D|Any object shape at all"
    correct="B"
-   explanation="FSA is the de-facto contract the Redux ecosystem agrees on. RTK&apos;s createAction produces FSA-compliant creators by default." %}
+   explanation="FSA is the de-facto contract the Redux ecosystem agrees on. RTK's createAction produces FSA-compliant creators by default." %}
 
 {% include quiz.html id="actions-4"
    question="How should you unit-test an action creator?"
-   options="A|You can&apos;t test action creators;B|Call the creator with input and assert the returned action object equals the expected shape (type + payload + any meta). For thunk creators, call the returned function with mocked dispatch/getState and assert the sequence of dispatches. Pure inputs in, asserted outputs out;C|Wrap it in a component and render;D|Integration-test via the UI only"
+   options="A|You can't test action creators;;B|Call the creator with input and assert the returned action object equals the expected shape (type + payload + any meta). For thunk creators, call the returned function with mocked dispatch/getState and assert the sequence of dispatches. Pure inputs in, asserted outputs out;;C|Wrap it in a component and render;;D|Integration-test via the UI only"
    correct="B"
    explanation="Action creators are pure fns (even thunks are fns), which makes them the easiest thing to test in the whole stack — a few expect(creator(args)).toEqual(...) calls." %}
 
 {% include quiz.html id="actions-5"
    question="Why keep action-type constants separate from action creators?"
-   options="A|It&apos;s a historical quirk;B|The constants are imported by reducers, middleware, sagas, devtools, and tests — centralising them prevents typos, makes rename refactors safe, and keeps the &quot;string catalog&quot; discoverable. In RTK, createSlice generates both for you so the concern is automated away;C|They must be in separate files for performance;D|Creators can&apos;t reference constants"
+   options="A|It's a historical quirk;;B|The constants are imported by reducers, middleware, sagas, devtools, and tests — centralising them prevents typos, makes rename refactors safe, and keeps the &quot;string catalog&quot; discoverable. In RTK, createSlice generates both for you so the concern is automated away;;C|They must be in separate files for performance;;D|Creators can't reference constants"
    correct="B"
-   explanation="A typo&apos;d string in one place is a bug that slips past TypeScript; a typo&apos;d imported constant is a compile error. RTK hides this by auto-deriving types from slice names." %}
+   explanation="A typo'd string in one place is a bug that slips past TypeScript; a typo'd imported constant is a compile error. RTK hides this by auto-deriving types from slice names." %}
 
 ## References

--- a/docs/state/middleware.md
+++ b/docs/state/middleware.md
@@ -431,31 +431,31 @@ const goodMiddleware = (store) => (next) => (action) => {
 
 {% include quiz.html id="middleware-1"
    question="What is the Redux middleware function signature?"
-   options="A|action => dispatch;B|({ getState, dispatch }) => next => action => { /* pre */ const result = next(action); /* post */ return result; } — a curried function that receives store API, the next middleware, and each dispatched action, and can inspect / transform / suppress / delay it before passing to next;C|store => void;D|It has no signature"
+   options="A|action => dispatch;;B|({ getState, dispatch }) => next => action => { /* pre */ const result = next(action); /* post */ return result; } — a curried function that receives store API, the next middleware, and each dispatched action, and can inspect / transform / suppress / delay it before passing to next;;C|store => void;;D|It has no signature"
    correct="B"
    explanation="That 3-level curry lets middlewares be composed with applyMiddleware. The double return lets you wrap async work around the next() call." %}
 
 {% include quiz.html id="middleware-2"
    question="Inside middleware, when should you call next(action) vs store.dispatch(action)?"
-   options="A|They&apos;re the same;B|next(action) continues the current pipeline past this middleware — use it for the action you&apos;re currently processing. store.dispatch(action) restarts the pipeline from the top — use it to emit a NEW action (e.g. dispatching a success action after an async call). Mixing them up causes infinite loops;C|Only use next;D|Only use dispatch"
+   options="A|They're the same;;B|next(action) continues the current pipeline past this middleware — use it for the action you're currently processing. store.dispatch(action) restarts the pipeline from the top — use it to emit a NEW action (e.g. dispatching a success action after an async call). Mixing them up causes infinite loops;;C|Only use next;;D|Only use dispatch"
    correct="B"
    explanation="next = forward the current action. dispatch = fire a fresh action through all middleware again. Dispatching the same action from middleware is the classic infinite-loop bug." %}
 
 {% include quiz.html id="middleware-3"
    question="Which is NOT a typical middleware use case?"
-   options="A|Logging every action for debugging;B|Attaching auth tokens / request IDs to async calls;C|Handling thunks, sagas, promises, observables (async orchestration);D|Storing component DOM refs"
+   options="A|Logging every action for debugging;;B|Attaching auth tokens / request IDs to async calls;;C|Handling thunks, sagas, promises, observables (async orchestration);;D|Storing component DOM refs"
    correct="D"
    explanation="Middleware is for cross-cutting concerns on the action pipeline: logging, auth, analytics, async orchestration, crash reporting. DOM refs have nothing to do with the action stream." %}
 
 {% include quiz.html id="middleware-4"
    question="Does middleware order matter?"
-   options="A|No — composition is commutative;B|Yes — each middleware wraps the next one. A logger placed BEFORE thunk logs the raw thunk function; placed AFTER thunk it logs the resolved action. Crash reporters belong last to catch errors thrown by earlier middleware. Order = pipeline order;C|Order only matters in production;D|Order only matters for sagas"
+   options="A|No — composition is commutative;;B|Yes — each middleware wraps the next one. A logger placed BEFORE thunk logs the raw thunk function; placed AFTER thunk it logs the resolved action. Crash reporters belong last to catch errors thrown by earlier middleware. Order = pipeline order;;C|Order only matters in production;;D|Order only matters for sagas"
    correct="B"
    explanation="applyMiddleware(a, b, c) means a wraps b wraps c. Shifting order changes which middleware sees the &quot;raw&quot; action vs already-transformed results." %}
 
 {% include quiz.html id="middleware-5"
    question="How do you unit-test a middleware?"
-   options="A|Boot a real app and interact with the UI;B|Construct fake store API ({ getState, dispatch }), a fake next spy, invoke middleware(storeAPI)(next)(action), then assert on what next was called with and what dispatch was called with. Pure function in, observable effects out;C|Middleware can&apos;t be tested;D|Only e2e tests work"
+   options="A|Boot a real app and interact with the UI;;B|Construct fake store API ({ getState, dispatch }), a fake next spy, invoke middleware(storeAPI)(next)(action), then assert on what next was called with and what dispatch was called with. Pure function in, observable effects out;;C|Middleware can't be tested;;D|Only e2e tests work"
    correct="B"
    explanation="Middleware is three nested functions — all pure. Mock the inputs, assert the outputs. No DOM, no real store needed." %}
 

--- a/docs/state/reducer.md
+++ b/docs/state/reducer.md
@@ -467,31 +467,31 @@ console.log(state);  // { count: 5 } - state preserved
 
 {% include quiz.html id="reducer-1"
    question="Why must reducers be pure functions?"
-   options="A|Purity is just a style preference;B|Reducers must be deterministic given (state, action), with no mutations or side effects, so that: Redux dev-tools can time-travel by replaying actions, Redux can rely on reference equality to know what changed, SSR returns consistent output, and tests only need inputs to assert outputs;C|Pure functions are faster at runtime;D|It&apos;s required by TypeScript"
+   options="A|Purity is just a style preference;;B|Reducers must be deterministic given (state, action), with no mutations or side effects, so that: Redux dev-tools can time-travel by replaying actions, Redux can rely on reference equality to know what changed, SSR returns consistent output, and tests only need inputs to assert outputs;;C|Pure functions are faster at runtime;;D|It's required by TypeScript"
    correct="B"
    explanation="Impurity (mutation, side effects, random, now()) breaks time travel, reference equality checks, and predictability — the core guarantees Redux is built on." %}
 
 {% include quiz.html id="reducer-2"
-   question="What&apos;s the idiomatic way to update a deeply-nested property immutably?"
-   options="A|Mutate it in place and call setState;B|Return a new outer object with spread, a new middle object with spread, a new inner object with the changed field — or use Immer (or RTK which uses Immer under the hood) to write mutating-looking code that produces an immutable update;C|JSON.parse(JSON.stringify(state));D|Reassign state.x.y directly"
+   question="What's the idiomatic way to update a deeply-nested property immutably?"
+   options="A|Mutate it in place and call setState;;B|Return a new outer object with spread, a new middle object with spread, a new inner object with the changed field — or use Immer (or RTK which uses Immer under the hood) to write mutating-looking code that produces an immutable update;;C|JSON.parse(JSON.stringify(state));;D|Reassign state.x.y directly"
    correct="B"
-   explanation="Manual spreads get verbose quickly, which is why RTK&apos;s createSlice is so popular — it lets you write state.todo.items.push(x) and Immer produces the immutable result." %}
+   explanation="Manual spreads get verbose quickly, which is why RTK's createSlice is so popular — it lets you write state.todo.items.push(x) and Immer produces the immutable result." %}
 
 {% include quiz.html id="reducer-3"
    question="What does combineReducers do?"
-   options="A|Nothing — decorative;B|Takes an object of slice reducers { todo, filters, config } and returns a single root reducer that calls each slice reducer with its slice of state and the same action, then assembles the results into { todo, filters, config }. That&apos;s how you scale from one reducer to many;C|Merges two states into one reducer;D|Deprecated in Redux 5"
+   options="A|Nothing — decorative;;B|Takes an object of slice reducers { todo, filters, config } and returns a single root reducer that calls each slice reducer with its slice of state and the same action, then assembles the results into { todo, filters, config }. That's how you scale from one reducer to many;;C|Merges two states into one reducer;;D|Deprecated in Redux 5"
    correct="B"
-   explanation="It&apos;s pure scaffolding that lets each slice own its key in the state tree. RTK&apos;s configureStore accepts the same object form." %}
+   explanation="It's pure scaffolding that lets each slice own its key in the state tree. RTK's configureStore accepts the same object form." %}
 
 {% include quiz.html id="reducer-4"
    question="How should reducers handle async work (fetches, timeouts, etc.)?"
-   options="A|Reducers should do the fetch themselves;B|Reducers stay pure and only react to actions. The async work lives in thunks / sagas / epics / listeners, which dispatch request/success/fail actions that the reducer handles predictably — often into an { status, data, error } shape;C|Reducers should call setTimeout;D|Redux can&apos;t do async"
+   options="A|Reducers should do the fetch themselves;;B|Reducers stay pure and only react to actions. The async work lives in thunks / sagas / epics / listeners, which dispatch request/success/fail actions that the reducer handles predictably — often into an { status, data, error } shape;;C|Reducers should call setTimeout;;D|Redux can't do async"
    correct="B"
    explanation="Keep reducers deterministic. Async -> actions -> reducer. The request/success/fail triple is the shared pattern across the Redux family." %}
 
 {% include quiz.html id="reducer-5"
    question="Which of these is a legitimate reducer composition pattern?"
-   options="A|Nothing — all reducers must be one giant switch;B|combineReducers for slice composition, calling a shared sub-reducer for a nested shape, a higher-order reducer that wraps another reducer to add behavior (e.g. undo/redo, reset-on-logout), and RTK&apos;s extraReducers letting slices respond to other slices&apos; actions;C|Just copy-paste reducers;D|Reducer composition is impossible"
+   options="A|Nothing — all reducers must be one giant switch;;B|combineReducers for slice composition, calling a shared sub-reducer for a nested shape, a higher-order reducer that wraps another reducer to add behavior (e.g. undo/redo, reset-on-logout), and RTK's extraReducers letting slices respond to other slices' actions;;C|Just copy-paste reducers;;D|Reducer composition is impossible"
    correct="B"
    explanation="Reducers are functions — they compose. combineReducers, sub-reducers, higher-order wrappers, and cross-slice listeners are the standard tools for keeping each reducer focused." %}
 

--- a/docs/state/selectors.md
+++ b/docs/state/selectors.md
@@ -309,31 +309,31 @@ function TodoList() {
 
 {% include quiz.html id="selectors-1"
    question="What problem does memoization (e.g. via Reselect/createSelector) solve in selectors?"
-   options="A|It makes selectors async;B|Expensive derivations (filtering, sorting, shaping) would re-run on every render. A memoized selector caches the last (inputs -&gt; output) pair and only recomputes when one of its input selectors returns a new reference — same inputs, same cached result, same reference, no downstream re-render;C|It&apos;s purely cosmetic;D|It caches HTTP responses"
+   options="A|It makes selectors async;;B|Expensive derivations (filtering, sorting, shaping) would re-run on every render. A memoized selector caches the last (inputs -> output) pair and only recomputes when one of its input selectors returns a new reference — same inputs, same cached result, same reference, no downstream re-render;;C|It's purely cosmetic;;D|It caches HTTP responses"
    correct="B"
    explanation="Without memoization, a component subscribing to a derived array or object would re-render after every store update because selector() returns a new array/object each time." %}
 
 {% include quiz.html id="selectors-2"
    question="How do you compose selectors?"
-   options="A|Inline them inside useSelector;B|Build small input selectors (state =&gt; slice.field), then use createSelector(input1, input2, ..., (a, b, ...) =&gt; derived) to compose them into output selectors. Output selectors can themselves be inputs to further selectors, so derivations stack in a dependency graph;C|Selectors cannot be composed;D|Only by copying code"
+   options="A|Inline them inside useSelector;;B|Build small input selectors (state => slice.field), then use createSelector(input1, input2, ..., (a, b, ...) => derived) to compose them into output selectors. Output selectors can themselves be inputs to further selectors, so derivations stack in a dependency graph;;C|Selectors cannot be composed;;D|Only by copying code"
    correct="B"
    explanation="Composition keeps each selector tiny and reusable. The dependency graph is what lets Reselect memoize correctly." %}
 
 {% include quiz.html id="selectors-3"
    question="When do you need a selector factory (createSelector inside a creator fn) vs a shared selector?"
-   options="A|Always use a factory;B|A plain memoized selector has ONE cache slot — if two components call it with different props (e.g. selectItemById(state, id) for two ids), the cache thrashes. A selector FACTORY returns a fresh memoized selector per component instance, so each instance has its own cache;C|Factories are a Redux 5 deprecation;D|They are identical"
+   options="A|Always use a factory;;B|A plain memoized selector has ONE cache slot — if two components call it with different props (e.g. selectItemById(state, id) for two ids), the cache thrashes. A selector FACTORY returns a fresh memoized selector per component instance, so each instance has its own cache;;C|Factories are a Redux 5 deprecation;;D|They are identical"
    correct="B"
-   explanation="Reselect&apos;s default cache size is 1. Per-instance memoization via a factory is the fix when a selector takes component-specific arguments." %}
+   explanation="Reselect's default cache size is 1. Per-instance memoization via a factory is the fix when a selector takes component-specific arguments." %}
 
 {% include quiz.html id="selectors-4"
    question="How do selectors help decouple components from the store shape?"
-   options="A|They don&apos;t — components still need to know the shape;B|Components call a selector by name (selectVisibleTodos) instead of reaching into state.todo.items.filter(...). If the state shape changes, only the selector file changes — every component keeps working. That&apos;s the key refactor-safety win;C|Selectors generate components;D|They replace containers"
+   options="A|They don't — components still need to know the shape;;B|Components call a selector by name (selectVisibleTodos) instead of reaching into state.todo.items.filter(...). If the state shape changes, only the selector file changes — every component keeps working. That's the key refactor-safety win;;C|Selectors generate components;;D|They replace containers"
    correct="B"
    explanation="Selectors are the abstraction barrier over state shape. A slice rename is a one-file refactor with selectors, a grep-and-pray refactor without them." %}
 
 {% include quiz.html id="selectors-5"
-   question="What&apos;s the difference between input selectors and output selectors in Reselect?"
-   options="A|There is no difference;B|Input selectors are simple state-readers (state =&gt; state.users). Output selectors are built via createSelector from one or more input selectors and a combiner function that produces the derived value. Keeping them separate maximizes reuse — the same input selectors feed many output selectors;C|Only output selectors can be memoized;D|Input selectors mutate state"
+   question="What's the difference between input selectors and output selectors in Reselect?"
+   options="A|There is no difference;;B|Input selectors are simple state-readers (state => state.users). Output selectors are built via createSelector from one or more input selectors and a combiner function that produces the derived value. Keeping them separate maximizes reuse — the same input selectors feed many output selectors;;C|Only output selectors can be memoized;;D|Input selectors mutate state"
    correct="B"
    explanation="Shared input selectors + focused output selectors is the composition pattern that lets a small set of primitives drive many derivations without duplicating work." %}
 

--- a/docs/state/state.md
+++ b/docs/state/state.md
@@ -348,31 +348,31 @@ const Dropdown = () => {
 
 {% include quiz.html id="state-1"
    question="What are the key differences between local, global, and server state?"
-   options="A|They are interchangeable;B|Local state belongs to a single component (input focus, modal open). Global state is shared across the app (auth user, theme, cart). Server state is remote data you cache on the client (API responses) — it has its own concerns: fetching, staleness, re-fetching, invalidation. Each typically wants a different tool;C|Only global state exists;D|Server state is a myth"
+   options="A|They are interchangeable;;B|Local state belongs to a single component (input focus, modal open). Global state is shared across the app (auth user, theme, cart). Server state is remote data you cache on the client (API responses) — it has its own concerns: fetching, staleness, re-fetching, invalidation. Each typically wants a different tool;;C|Only global state exists;;D|Server state is a myth"
    correct="B"
-   explanation="Local -&gt; useState. Global -&gt; Redux/Pinia/NgRx/Zustand/Context. Server -&gt; React Query/SWR/RTK Query — the last one has enough unique concerns (cache, invalidation, deduping) to warrant its own tool." %}
+   explanation="Local -> useState. Global -> Redux/Pinia/NgRx/Zustand/Context. Server -> React Query/SWR/RTK Query — the last one has enough unique concerns (cache, invalidation, deduping) to warrant its own tool." %}
 
 {% include quiz.html id="state-2"
    question="Should you always lift state to the highest common ancestor?"
-   options="A|Yes, always lift to the top;B|No. Lift only as high as the components that genuinely need to read or update it. Over-lifting causes unnecessary re-renders across the tree and forces prop-drilling. If many distant components need it, reach for context or a store instead of the highest ancestor;C|Never lift state;D|Only lift class components"
+   options="A|Yes, always lift to the top;;B|No. Lift only as high as the components that genuinely need to read or update it. Over-lifting causes unnecessary re-renders across the tree and forces prop-drilling. If many distant components need it, reach for context or a store instead of the highest ancestor;;C|Never lift state;;D|Only lift class components"
    correct="B"
    explanation="&quot;Lift to the closest common ancestor&quot; — not the root. If that ancestor is too far, a store or context is probably the right tool, not deeper lifting." %}
 
 {% include quiz.html id="state-3"
    question="Why does state immutability matter?"
-   options="A|It&apos;s purely stylistic;B|Reference equality checks (Redux, React.memo, useMemo deps, Svelte stores) depend on new references for new values. Mutating state in place means consumers can&apos;t detect the change, dev-tools time-travel breaks, and concurrent rendering can observe inconsistent state. Immutability is the contract that makes those features work;C|Only strings can be immutable;D|Immutability is a performance regression"
+   options="A|It's purely stylistic;;B|Reference equality checks (Redux, React.memo, useMemo deps, Svelte stores) depend on new references for new values. Mutating state in place means consumers can't detect the change, dev-tools time-travel breaks, and concurrent rendering can observe inconsistent state. Immutability is the contract that makes those features work;;C|Only strings can be immutable;;D|Immutability is a performance regression"
    correct="B"
    explanation="Every framework relying on structural sharing / reference-equality shortcutting needs immutability. Immer and RTK let you write mutating-looking code while preserving the guarantee." %}
 
 {% include quiz.html id="state-4"
    question="What is normalised state and when is it useful?"
-   options="A|Flattening nested entities into { byId: {id: entity}, allIds: [id] } shapes so each entity lives in exactly one place, references are ids, and updates don&apos;t require deep mutation. Most useful for server-data heavy apps with cross-references (users, posts, comments);B|It&apos;s always wrong;C|It doubles your bundle;D|Normalisation is a Vue-only concept"
+   options="A|Flattening nested entities into { byId: {id: entity}, allIds: [id] } shapes so each entity lives in exactly one place, references are ids, and updates don't require deep mutation. Most useful for server-data heavy apps with cross-references (users, posts, comments);;B|It's always wrong;;C|It doubles your bundle;;D|Normalisation is a Vue-only concept"
    correct="A"
    explanation="When the same entity appears in many places, nested state becomes a sync nightmare. Normalisation (see createEntityAdapter in RTK) keeps a single source of truth." %}
 
 {% include quiz.html id="state-5"
    question="How should you choose between useState, Context, Redux/Pinia/NgRx, and a server-state library?"
-   options="A|Always use the biggest tool;B|Start with useState for local component state. Use Context for small, rarely-changing shared values (theme, locale, auth user) — but not for high-churn data. Use a store (Redux/Pinia/NgRx) when global state is complex, cross-cutting, devtools matter, or many slices interact. Use a server-state library (React Query, RTK Query) for remote data caching, invalidation, and refetch;C|Always use Redux;D|Never use Context"
+   options="A|Always use the biggest tool;;B|Start with useState for local component state. Use Context for small, rarely-changing shared values (theme, locale, auth user) — but not for high-churn data. Use a store (Redux/Pinia/NgRx) when global state is complex, cross-cutting, devtools matter, or many slices interact. Use a server-state library (React Query, RTK Query) for remote data caching, invalidation, and refetch;;C|Always use Redux;;D|Never use Context"
    correct="B"
    explanation="Match the tool to the actual problem. Context for infrequent shared config, a store for complex client state, a server-state lib for remote data — those three cover almost every need in a modern app." %}
 

--- a/docs/state/store.md
+++ b/docs/state/store.md
@@ -433,32 +433,32 @@ const state = {
 ## Quick Quiz
 
 {% include quiz.html id="store-1"
-   question="What&apos;s the main benefit of a centralised store over passing props?"
-   options="A|A store is faster on the CPU;B|The store is a single source of truth any component can subscribe to without prop-drilling through intermediate components. It makes data flow predictable (dispatch -&gt; reducer -&gt; new state -&gt; selective subscriber re-renders), decouples senders from receivers, and enables devtools time travel;C|Props were deprecated;D|It bypasses React"
+   question="What's the main benefit of a centralised store over passing props?"
+   options="A|A store is faster on the CPU;;B|The store is a single source of truth any component can subscribe to without prop-drilling through intermediate components. It makes data flow predictable (dispatch -> reducer -> new state -> selective subscriber re-renders), decouples senders from receivers, and enables devtools time travel;;C|Props were deprecated;;D|It bypasses React"
    correct="B"
    explanation="For cross-cutting concerns (auth, theme, cart, feature flags) a store beats threading props through 6 layers. For local-only data, props are still the right tool." %}
 
 {% include quiz.html id="store-2"
    question="What is a reducer and why is it called that?"
-   options="A|It reduces code size;B|It&apos;s the same shape as a function you&apos;d pass to Array.prototype.reduce — (accumulator, next) =&gt; newAccumulator. A Redux reducer is (state, action) =&gt; newState: you can conceptually .reduce the entire action history into the current state. That&apos;s the provenance of the name;C|It&apos;s a marketing term;D|It&apos;s unrelated to Array.reduce"
+   options="A|It reduces code size;;B|It's the same shape as a function you'd pass to Array.prototype.reduce — (accumulator, next) => newAccumulator. A Redux reducer is (state, action) => newState: you can conceptually .reduce the entire action history into the current state. That's the provenance of the name;;C|It's a marketing term;;D|It's unrelated to Array.reduce"
    correct="B"
-   explanation="The naming isn&apos;t arbitrary — Redux&apos;s state at any moment equals all past actions reduced over the initial state via the reducer. That&apos;s also what enables time-travel debugging." %}
+   explanation="The naming isn't arbitrary — Redux's state at any moment equals all past actions reduced over the initial state via the reducer. That's also what enables time-travel debugging." %}
 
 {% include quiz.html id="store-3"
    question="When should you reach for Redux vs lighter options like Context or Zustand?"
-   options="A|Always use Redux;B|Use Context for small, low-churn shared values (theme, auth user). Use Zustand/Jotai/Valtio for lightweight client state without middleware machinery. Use Redux (especially RTK) when you want opinionated structure, powerful devtools, middleware ecosystem, or cross-cutting async orchestration via sagas/listeners — particularly in larger apps and teams;C|Only Context works with server state;D|Zustand is deprecated"
+   options="A|Always use Redux;;B|Use Context for small, low-churn shared values (theme, auth user). Use Zustand/Jotai/Valtio for lightweight client state without middleware machinery. Use Redux (especially RTK) when you want opinionated structure, powerful devtools, middleware ecosystem, or cross-cutting async orchestration via sagas/listeners — particularly in larger apps and teams;;C|Only Context works with server state;;D|Zustand is deprecated"
    correct="B"
-   explanation="Match the tool to the app&apos;s scale and team needs. RTK has dramatically narrowed the &quot;Redux is heavy&quot; gap; Zustand is ideal when you want less ceremony." %}
+   explanation="Match the tool to the app's scale and team needs. RTK has dramatically narrowed the &quot;Redux is heavy&quot; gap; Zustand is ideal when you want less ceremony." %}
 
 {% include quiz.html id="store-4"
-   question="What&apos;s the difference between calling dispatch(action) and calling a function that updates state directly?"
-   options="A|They are functionally identical;B|dispatch routes the action through all middleware (logging, thunks, analytics, crash reporting) and produces a serialized, time-travel-able event; a direct function call is opaque to devtools, un-replayable, and doesn&apos;t get middleware cross-cutting concerns. dispatch is the unified event bus;C|Direct function calls are faster and preferred;D|dispatch is a UI-only API"
+   question="What's the difference between calling dispatch(action) and calling a function that updates state directly?"
+   options="A|They are functionally identical;;B|dispatch routes the action through all middleware (logging, thunks, analytics, crash reporting) and produces a serialized, time-travel-able event; a direct function call is opaque to devtools, un-replayable, and doesn't get middleware cross-cutting concerns. dispatch is the unified event bus;;C|Direct function calls are faster and preferred;;D|dispatch is a UI-only API"
    correct="B"
    explanation="Actions + dispatch are an event log. Direct state mutation is off-the-books. Devtools, replayability, and middleware ALL rely on going through dispatch." %}
 
 {% include quiz.html id="store-5"
    question="Can you have multiple stores in a single application?"
-   options="A|Yes, and you should — one per component;B|Technically yes (Redux allows multiple stores and NgRx supports feature stores), but the standard advice is a SINGLE app-wide store with slices. Multiple independent stores fragment devtools, complicate cross-slice logic, and usually indicate a design that would be cleaner as slices of one store. Exceptions: micro-frontends with isolated domains;C|No — Redux forbids multiple stores entirely;D|Multiple stores only work in Vue"
+   options="A|Yes, and you should — one per component;;B|Technically yes (Redux allows multiple stores and NgRx supports feature stores), but the standard advice is a SINGLE app-wide store with slices. Multiple independent stores fragment devtools, complicate cross-slice logic, and usually indicate a design that would be cleaner as slices of one store. Exceptions: micro-frontends with isolated domains;;C|No — Redux forbids multiple stores entirely;;D|Multiple stores only work in Vue"
    correct="B"
    explanation="Pinia naturally has multiple stores by design. Redux philosophy is one store with slices. Either way, needing many independent stores usually means something should be a slice." %}
 

--- a/docs/ui/accessibility.md
+++ b/docs/ui/accessibility.md
@@ -718,31 +718,31 @@ function submitForm() {
 
 {% include quiz.html id="accessibility-1"
    question="What is the essential difference between semantic HTML and ARIA?"
-   options="A|ARIA is newer and should be preferred over HTML;B|Semantic HTML provides real behavior (keyboard, focus, AT semantics) automatically, while ARIA only adds meaning without behavior — you still have to add the keyboard handlers yourself;C|ARIA is used only in React apps;D|They are interchangeable"
+   options="A|ARIA is newer and should be preferred over HTML;;B|Semantic HTML provides real behavior (keyboard, focus, AT semantics) automatically, while ARIA only adds meaning without behavior — you still have to add the keyboard handlers yourself;;C|ARIA is used only in React apps;;D|They are interchangeable"
    correct="B"
-   explanation="The first rule of ARIA is &quot;don't use ARIA.&quot; &lt;button&gt; gets Tab/Enter/Space, focus, and role=button for free. A &lt;div role=&quot;button&quot;&gt; needs tabindex, keydown handlers, and the role all wired manually." %}
+   explanation="The first rule of ARIA is &quot;don't use ARIA.&quot; <button> gets Tab/Enter/Space, focus, and role=button for free. A <div role=&quot;button&quot;> needs tabindex, keydown handlers, and the role all wired manually." %}
 
 {% include quiz.html id="accessibility-2"
    question="Which of these is the correct way to make a custom dropdown usable by a screen reader and keyboard?"
-   options="A|Add a click handler and hope for the best;B|Wrap it in a &lt;details&gt; element;C|Use aria-haspopup / aria-expanded / aria-controls on the trigger, role=&quot;listbox&quot; on the menu, keyboard handlers for arrows/Enter/Escape, and proper focus management;D|Rely on CSS :focus-visible alone"
+   options="A|Add a click handler and hope for the best;;B|Wrap it in a <details> element;;C|Use aria-haspopup / aria-expanded / aria-controls on the trigger, role=&quot;listbox&quot; on the menu, keyboard handlers for arrows/Enter/Escape, and proper focus management;;D|Rely on CSS :focus-visible alone"
    correct="C"
    explanation="A custom dropdown needs ARIA states on trigger and list, keyboard handling for Up/Down/Enter/Escape, and focus moved into the listbox when open and back to the trigger on close." %}
 
 {% include quiz.html id="accessibility-3"
    question="What three things must a modal dialog do to trap focus correctly?"
-   options="A|Save the previously focused element, move focus into the modal, and on close restore focus to the saved element (plus wrap Tab/Shift+Tab inside the modal);B|Nothing — browsers handle modals automatically;C|Disable Tab globally while the modal is open;D|Only prevent scroll"
+   options="A|Save the previously focused element, move focus into the modal, and on close restore focus to the saved element (plus wrap Tab/Shift+Tab inside the modal);;B|Nothing — browsers handle modals automatically;;C|Disable Tab globally while the modal is open;;D|Only prevent scroll"
    correct="A"
    explanation="Without this pattern, Tab leaks behind the overlay, users lose their place on close, and screen readers get disoriented." %}
 
 {% include quiz.html id="accessibility-4"
    question="When should you use aria-live=&quot;assertive&quot; vs aria-live=&quot;polite&quot;?"
-   options="A|Use assertive for everything so users never miss a message;B|Use assertive for urgent interruptions (form errors, auth failures) and polite for status updates (loading, counts, success toasts) so the screen reader finishes what it was saying first;C|They have no practical difference;D|Only use assertive for animations"
+   options="A|Use assertive for everything so users never miss a message;;B|Use assertive for urgent interruptions (form errors, auth failures) and polite for status updates (loading, counts, success toasts) so the screen reader finishes what it was saying first;;C|They have no practical difference;;D|Only use assertive for animations"
    correct="B"
    explanation="Assertive interrupts the current speech; overuse trains users to tune it out. Reserve it for things that change what the user should do right now." %}
 
 {% include quiz.html id="accessibility-5"
    question="What is the WCAG AA minimum contrast ratio for normal body text?"
-   options="A|3 to 1;B|4.5 to 1;C|7 to 1;D|There is no minimum"
+   options="A|3 to 1;;B|4.5 to 1;;C|7 to 1;;D|There is no minimum"
    correct="B"
    explanation="AA requires 4.5:1 for normal text and 3:1 for large text (18pt or 14pt bold). AAA bumps those to 7:1 and 4.5:1 respectively." %}
 

--- a/docs/ui/atom.md
+++ b/docs/ui/atom.md
@@ -231,31 +231,31 @@ const IconButton = ({ onClick, icon, ariaLabel }) => (
 
 {% include quiz.html id="atom-1"
    question="What is the primary characteristic that defines a component as an 'atom' in Atomic Design?"
-   options="A|It manages its own global state;B|It has a single responsibility and cannot be broken down into smaller functional components;C|It always wraps at least three child elements;D|It fetches its own data from an API"
+   options="A|It manages its own global state;;B|It has a single responsibility and cannot be broken down into smaller functional components;;C|It always wraps at least three child elements;;D|It fetches its own data from an API"
    correct="B"
    explanation="Atoms are the smallest functional units of a UI — a button, an input, an icon. Keeping the responsibility single-purpose is what makes them reusable across contexts." %}
 
 {% include quiz.html id="atom-2"
    question="Should an atom component contain API calls and business logic to make it self-sufficient?"
-   options="A|Yes — self-sufficient atoms are easier to drop into any page;B|No — atoms should be purely presentational and receive data via props"
+   options="A|Yes — self-sufficient atoms are easier to drop into any page;;B|No — atoms should be purely presentational and receive data via props"
    correct="B"
    explanation="Business logic, API calls, and state management belong in containers or higher-level components. A button that makes an API call can only be used in one specific scenario; a pure atom can be used anywhere." %}
 
 {% include quiz.html id="atom-3"
    question="Which of these is a well-designed atom?"
-   options="A|A LoginForm with email input, password input, and a submit button;B|A TextInput that accepts `value` and `onChange` props;C|A UserProfile that displays avatar, name, and bio"
+   options="A|A LoginForm with email input, password input, and a submit button;;B|A TextInput that accepts `value` and `onChange` props;;C|A UserProfile that displays avatar, name, and bio"
    correct="B"
    explanation="A is a molecule/organism (combines multiple atoms + business logic). C is a molecule (several display elements bound to a specific data shape). B — a single-purpose text input with a simple interface — is the atom." %}
 
 {% include quiz.html id="atom-4"
    question="What's the main benefit of wrapping a native HTML element in an atom component instead of using it directly?"
-   options="A|It hides implementation details so callers can't misuse it;B|It centralises styling, accessibility, and design-token usage so every instance stays consistent;C|It makes the bundle smaller;D|It is required by React 19"
+   options="A|It hides implementation details so callers can't misuse it;;B|It centralises styling, accessibility, and design-token usage so every instance stays consistent;;C|It makes the bundle smaller;;D|It is required by React 19"
    correct="B"
    explanation="Atom components give you one place to set padding, colors, ARIA attributes, and hover states so that every button/input/icon in the app inherits them automatically — the 'slightly different button everywhere' problem goes away." %}
 
 {% include quiz.html id="atom-5"
    question="How should an atom handle visual variants like `primary`, `secondary`, `danger`?"
-   options="A|Create separate `PrimaryButton`, `SecondaryButton`, `DangerButton` components;B|Expose a `variant` prop on a single atom and switch classNames/styles based on it;C|Duplicate the atom per theme and import the right one per route"
+   options="A|Create separate `PrimaryButton`, `SecondaryButton`, `DangerButton` components;;B|Expose a `variant` prop on a single atom and switch classNames/styles based on it;;C|Duplicate the atom per theme and import the right one per route"
    correct="B"
    explanation="A single atom with a `variant` prop scales from 2 variants to 20 without proliferating files. Only split into separate components when the *behavior* (not just styling) differs significantly." %}
 

--- a/docs/ui/atomic-design.md
+++ b/docs/ui/atomic-design.md
@@ -894,31 +894,31 @@ function CategoryPage() {
 
 {% include quiz.html id="atomic-design-1"
    question="What are the five levels of Atomic Design, in order from smallest to largest?"
-   options="A|Pages -> Templates -> Organisms -> Molecules -> Atoms;B|Atoms -> Molecules -> Organisms -> Templates -> Pages;C|Components -> Containers -> Layouts -> Screens -> Apps;D|Elements -> Modules -> Features -> Routes -> Sites"
+   options="A|Pages -> Templates -> Organisms -> Molecules -> Atoms;;B|Atoms -> Molecules -> Organisms -> Templates -> Pages;;C|Components -> Containers -> Layouts -> Screens -> Apps;;D|Elements -> Modules -> Features -> Routes -> Sites"
    correct="B"
    explanation="Brad Frost's hierarchy moves from the smallest indivisible pieces up to full content-bearing pages: Atoms, Molecules, Organisms, Templates, Pages." %}
 
 {% include quiz.html id="atomic-design-2"
    question="What is the key difference between a Template and a Page?"
-   options="A|Templates have styling, pages do not;B|Templates are content-agnostic layout skeletons (placeholders); pages are specific instances of templates with real representative content;C|Templates live on the server, pages live on the client;D|They are the same thing"
+   options="A|Templates have styling, pages do not;;B|Templates are content-agnostic layout skeletons (placeholders); pages are specific instances of templates with real representative content;;C|Templates live on the server, pages live on the client;;D|They are the same thing"
    correct="B"
    explanation="Templates define the layout and component wiring using placeholders; pages plug in realistic content so you can validate how the UI behaves with real data and edge cases." %}
 
 {% include quiz.html id="atomic-design-3"
    question="Which of these is the most accurate definition of a molecule?"
-   options="A|Anything bigger than an atom;B|A purposeful grouping of atoms (and sometimes smaller molecules) that forms a single reusable UI pattern;C|A stateful component;D|A component containing HTTP calls"
+   options="A|Anything bigger than an atom;;B|A purposeful grouping of atoms (and sometimes smaller molecules) that forms a single reusable UI pattern;;C|A stateful component;;D|A component containing HTTP calls"
    correct="B"
    explanation="Molecules combine atoms into cohesive, reusable patterns (SearchBar = Input + Button + Icon). They should still be largely presentational." %}
 
 {% include quiz.html id="atomic-design-4"
    question="When does it make sense to promote a molecule to an organism?"
-   options="A|Once it has any state;B|When it starts composing multiple molecules and represents a distinct, self-contained section of the UI (e.g. SiteHeader with Logo + Nav + Search);C|When it needs to be styled with CSS;D|Never — organisms are legacy"
+   options="A|Once it has any state;;B|When it starts composing multiple molecules and represents a distinct, self-contained section of the UI (e.g. SiteHeader with Logo + Nav + Search);;C|When it needs to be styled with CSS;;D|Never — organisms are legacy"
    correct="B"
    explanation="Organisms are where multiple molecules come together to form meaningful UI sections. If a &quot;molecule&quot; is orchestrating several other molecules, it has earned organism status." %}
 
 {% include quiz.html id="atomic-design-5"
    question="Why is a shared atomic-design vocabulary useful across a team?"
-   options="A|It lets you skip design reviews;B|It gives designers, developers and PMs a common chemistry-based language — &quot;this is a molecule, not an organism&quot; — which speeds up communication and prevents accidental duplication;C|It forces everyone to use React;D|It is required by WCAG"
+   options="A|It lets you skip design reviews;;B|It gives designers, developers and PMs a common chemistry-based language — &quot;this is a molecule, not an organism&quot; — which speeds up communication and prevents accidental duplication;;C|It forces everyone to use React;;D|It is required by WCAG"
    correct="B"
    explanation="The naming hierarchy is the whole point: once everyone uses the same words for the same scopes, architectural discussions and PR reviews get dramatically shorter." %}
 

--- a/docs/ui/attributes.md
+++ b/docs/ui/attributes.md
@@ -387,31 +387,31 @@ All event handler attributes accept a string. The string will be used to synthes
 
 {% include quiz.html id="attributes-1"
    question="What is the difference between an HTML attribute and a JS property on a DOM element?"
-   options="A|They are always the same thing;B|Attributes are declared in HTML and reflect the initial value; properties are live JS fields on the DOM node. For many (value, checked, href) they diverge after user interaction — the attribute stays at its initial value, the property tracks the current one;C|Attributes are slower to read;D|Properties only exist in React"
+   options="A|They are always the same thing;;B|Attributes are declared in HTML and reflect the initial value; properties are live JS fields on the DOM node. For many (value, checked, href) they diverge after user interaction — the attribute stays at its initial value, the property tracks the current one;;C|Attributes are slower to read;;D|Properties only exist in React"
    correct="B"
    explanation="Use getAttribute()/setAttribute() when you need HTML semantics or data attributes. Use the property (element.value, element.checked) when you want current runtime state." %}
 
 {% include quiz.html id="attributes-2"
    question="How do boolean attributes in HTML work?"
-   options="A|You set them to &quot;true&quot; or &quot;false&quot;;B|Their presence alone is truthy — &lt;input disabled&gt;, &lt;input disabled=&quot;&quot;&gt;, and &lt;input disabled=&quot;disabled&quot;&gt; all mean disabled. To turn them off, remove the attribute entirely;C|They don't exist in HTML;D|They only work on form elements"
+   options="A|You set them to the string 'true' or 'false';;B|Their presence alone is truthy — <input disabled>, <input disabled=''>, and <input disabled='disabled'> all mean disabled. To turn them off, remove the attribute entirely;;C|They don't exist in HTML;;D|They only work on form elements"
    correct="B"
    explanation="`disabled=&quot;false&quot;` is a classic footgun — it's still disabled because the attribute is present. Use removeAttribute or the property (el.disabled = false) to clear it." %}
 
 {% include quiz.html id="attributes-3"
    question="What are data-* attributes best used for?"
-   options="A|Styling;B|Storing small amounts of custom data on an element that JS can read via dataset.* — useful for component hooks, test ids, and feature flags without polluting the standard attribute namespace;C|Replacing global state;D|Replacing JSON APIs"
+   options="A|Styling;;B|Storing small amounts of custom data on an element that JS can read via dataset.* — useful for component hooks, test ids, and feature flags without polluting the standard attribute namespace;;C|Replacing global state;;D|Replacing JSON APIs"
    correct="B"
-   explanation="&lt;li data-id=&quot;42&quot;&gt; -> el.dataset.id === '42'. Great for delegation handlers and tests. Don't abuse them as a substitute for real state storage." %}
+   explanation="<li data-id=&quot;42&quot;> -> el.dataset.id === '42'. Great for delegation handlers and tests. Don't abuse them as a substitute for real state storage." %}
 
 {% include quiz.html id="attributes-4"
    question="Why do ARIA attributes matter even when the UI looks fine visually?"
-   options="A|They add fancy animations;B|They convey role, state, and relationship info to assistive technology (screen readers, switch controls) that sighted mouse users never see — without them your nice-looking custom widget is unusable to many users;C|They make the bundle smaller;D|They only affect SEO"
+   options="A|They add fancy animations;;B|They convey role, state, and relationship info to assistive technology (screen readers, switch controls) that sighted mouse users never see — without them your nice-looking custom widget is unusable to many users;;C|They make the bundle smaller;;D|They only affect SEO"
    correct="B"
-   explanation="A button made from &lt;div onclick&gt; looks fine but a screen reader can't announce it as a button without role=&quot;button&quot; plus keyboard wiring — or, better, just use &lt;button&gt;." %}
+   explanation="A button made from <div onclick> looks fine but a screen reader can't announce it as a button without role=&quot;button&quot; plus keyboard wiring — or, better, just use <button>." %}
 
 {% include quiz.html id="attributes-5"
    question="What's the safest way to set an href or src from user-controlled input?"
-   options="A|Concatenate it directly into innerHTML;B|Set via setAttribute, validate the URL (reject javascript: / data: schemes you don't intend), and encode untrusted pieces — innerHTML with untrusted strings is the standard XSS vector;C|Use eval();D|URL-encode then base64 it"
+   options="A|Concatenate it directly into innerHTML;;B|Set via setAttribute, validate the URL (reject javascript: / data: schemes you don't intend), and encode untrusted pieces — innerHTML with untrusted strings is the standard XSS vector;;C|Use eval();;D|URL-encode then base64 it"
    correct="B"
    explanation="Always treat user input as untrusted. Use setAttribute / the property setter, validate the URL scheme, and never interpolate untrusted strings into innerHTML." %}
 

--- a/docs/ui/component.md
+++ b/docs/ui/component.md
@@ -513,31 +513,31 @@ const ProductList = ({ products }) => {
 
 {% include quiz.html id="component-1"
    question="What are the three core technologies that make up a Web Component?"
-   options="A|HTML, CSS, JavaScript;B|Custom Elements, Shadow DOM, HTML Templates;C|React, Vue, Angular;D|JSX, Virtual DOM, Fiber"
+   options="A|HTML, CSS, JavaScript;;B|Custom Elements, Shadow DOM, HTML Templates;;C|React, Vue, Angular;;D|JSX, Virtual DOM, Fiber"
    correct="B"
-   explanation="Custom Elements let you define new HTML tags, Shadow DOM encapsulates styling and markup, and &lt;template&gt;/&lt;slot&gt; provide reusable markup fragments. Together they are the framework-agnostic component model baked into the browser." %}
+   explanation="Custom Elements let you define new HTML tags, Shadow DOM encapsulates styling and markup, and <template>/<slot> provide reusable markup fragments. Together they are the framework-agnostic component model baked into the browser." %}
 
 {% include quiz.html id="component-2"
    question="What is the primary difference between a presentational component and a container component?"
-   options="A|Presentational components own application state, containers only render UI;B|Presentational components render UI from props (no data fetching or global state); container components own data fetching, selectors, and dispatch — they pass that data down to presentational components;C|Presentational is React-only; containers are Angular-only;D|There is no real difference"
+   options="A|Presentational components own application state, containers only render UI;;B|Presentational components render UI from props (no data fetching or global state); container components own data fetching, selectors, and dispatch — they pass that data down to presentational components;;C|Presentational is React-only; containers are Angular-only;;D|There is no real difference"
    correct="B"
    explanation="The split keeps UI reusable and testable. Presentational components are pure-ish (props -> UI). Containers are the glue between state management and the UI layer." %}
 
 {% include quiz.html id="component-3"
    question="Should components always manage their own state internally rather than receiving it via props?"
-   options="A|Yes — self-contained components are easier to reason about;B|No — components should receive what they display via props; local state is reserved for truly component-internal concerns (menu open/closed, input focus) while shared or persistent state lives in a store or parent"
+   options="A|Yes — self-contained components are easier to reason about;;B|No — components should receive what they display via props; local state is reserved for truly component-internal concerns (menu open/closed, input focus) while shared or persistent state lives in a store or parent"
    correct="B"
    explanation="Over-locating state inside components leads to duplication, poor reuse, and hard-to-test components. Lift state up or use a store for anything that multiple components need." %}
 
 {% include quiz.html id="component-4"
    question="What's the main benefit of component-scoped CSS (CSS Modules, styled-components, Vue scoped styles)?"
-   options="A|It makes the bundle smaller;B|Class names are automatically localised so styles from one component can't accidentally bleed into another — you stop fighting with global CSS specificity;C|It enables server-side rendering;D|It replaces accessibility"
+   options="A|It makes the bundle smaller;;B|Class names are automatically localised so styles from one component can't accidentally bleed into another — you stop fighting with global CSS specificity;;C|It enables server-side rendering;;D|It replaces accessibility"
    correct="B"
    explanation="Scoped CSS eliminates the &quot;why is my .button style getting overridden by that other .button&quot; class of bug and lets components be drop-in reusable across pages and apps." %}
 
 {% include quiz.html id="component-5"
    question="When should you split a component into smaller components?"
-   options="A|Only when a designer asks you to;B|When it exceeds 500 lines, as a hard rule;C|When a part of it is reused elsewhere, when responsibilities diverge (render vs fetch), when a piece is testable in isolation, or when naming the sub-part suddenly makes the parent clearer;D|Never — always keep components big"
+   options="A|Only when a designer asks you to;;B|When it exceeds 500 lines, as a hard rule;;C|When a part of it is reused elsewhere, when responsibilities diverge (render vs fetch), when a piece is testable in isolation, or when naming the sub-part suddenly makes the parent clearer;;D|Never — always keep components big"
    correct="C"
    explanation="Extraction should be driven by reuse, single-responsibility, or clarity gains — not by a line-count rule. Splitting that doesn't meet one of those bars just adds indirection." %}
 

--- a/docs/ui/dom.md
+++ b/docs/ui/dom.md
@@ -368,31 +368,31 @@ button.remove();
 
 {% include quiz.html id="dom-1"
    question="What is the key difference between textContent and innerHTML when updating a DOM element?"
-   options="A|They are identical;B|textContent sets plain text and is safe for untrusted input; innerHTML parses the value as HTML, so passing untrusted input can lead to XSS and also triggers more expensive parsing/reflow;C|innerHTML is faster for all content;D|textContent runs JavaScript embedded in strings"
+   options="A|They are identical;;B|textContent sets plain text and is safe for untrusted input; innerHTML parses the value as HTML, so passing untrusted input can lead to XSS and also triggers more expensive parsing/reflow;;C|innerHTML is faster for all content;;D|textContent runs JavaScript embedded in strings"
    correct="B"
    explanation="Use textContent for text. Only use innerHTML when you genuinely need to insert markup, and never with unsanitised user input — that's the classic XSS vector." %}
 
 {% include quiz.html id="dom-2"
    question="Which of these actions does NOT cause a DOM reflow?"
-   options="A|Reading element.offsetWidth;B|Changing an element's width in px;C|Toggling `display: none`;D|Changing only the color property"
+   options="A|Reading element.offsetWidth;;B|Changing an element's width in px;;C|Toggling `display: none`;;D|Changing only the color property"
    correct="D"
    explanation="Reflow is triggered by layout-affecting changes (size, position, display) and by layout-reading properties (offset*, getBoundingClientRect). Pure paint changes like color just repaint, not reflow." %}
 
 {% include quiz.html id="dom-3"
    question="What's the practical difference between document.querySelector('#id') and document.getElementById('id')?"
-   options="A|getElementById is faster and returns only an Element or null; querySelector accepts any CSS selector (more flexible, slightly slower) and returns the first match or null;B|They are identical;C|getElementById can match by class too;D|querySelector only works inside React"
+   options="A|getElementById is faster and returns only an Element or null; querySelector accepts any CSS selector (more flexible, slightly slower) and returns the first match or null;;B|They are identical;;C|getElementById can match by class too;;D|querySelector only works inside React"
    correct="A"
    explanation="Use getElementById when you already have the id — it's direct lookup. querySelector is the Swiss-army version when you need a broader selector." %}
 
 {% include quiz.html id="dom-4"
    question="How does event delegation reduce the number of event listeners you need?"
-   options="A|It attaches one listener on a common ancestor and uses event.target to identify which descendant actually triggered the event, so dynamically added children are handled automatically;B|It silently dedupes listeners on the same element;C|It disables bubbling;D|It is a React-only concept"
+   options="A|It attaches one listener on a common ancestor and uses event.target to identify which descendant actually triggered the event, so dynamically added children are handled automatically;;B|It silently dedupes listeners on the same element;;C|It disables bubbling;;D|It is a React-only concept"
    correct="A"
-   explanation="Especially useful for long or dynamic lists — one listener on the &lt;ul&gt; beats a listener per &lt;li&gt;, and new items don't need to be wired up." %}
+   explanation="Especially useful for long or dynamic lists — one listener on the <ul> beats a listener per <li>, and new items don't need to be wired up." %}
 
 {% include quiz.html id="dom-5"
    question="What is a DocumentFragment good for?"
-   options="A|Only for SVG;B|Batching DOM nodes off-DOM and appending them in a single operation, so you pay the reflow/paint cost once instead of once per node;C|Replacing the whole document;D|Loading HTML from a URL"
+   options="A|Only for SVG;;B|Batching DOM nodes off-DOM and appending them in a single operation, so you pay the reflow/paint cost once instead of once per node;;C|Replacing the whole document;;D|Loading HTML from a URL"
    correct="B"
    explanation="Build your subtree in a DocumentFragment, then appendChild it. The fragment itself isn't rendered; the child nodes get moved into the document in a single operation." %}
 

--- a/docs/ui/element.md
+++ b/docs/ui/element.md
@@ -174,31 +174,31 @@ const newEl = <h1>Bye</h1>;
 
 {% include quiz.html id="element-1"
    question="What is the difference between a React element and a DOM element?"
-   options="A|They are the same thing;B|A React element is a plain JS object describing what should be rendered (type, props, children) — it is immutable; a DOM element is the actual browser node in the document. React reconciles elements into DOM nodes;C|A React element is slower than a DOM element;D|React elements live on the server"
+   options="A|They are the same thing;;B|A React element is a plain JS object describing what should be rendered (type, props, children) — it is immutable; a DOM element is the actual browser node in the document. React reconciles elements into DOM nodes;;C|A React element is slower than a DOM element;;D|React elements live on the server"
    correct="B"
    explanation="`React.createElement(...)` returns a description. React's reconciler then diffs and applies changes to real DOM nodes. The element itself is throwaway and cheap to recreate." %}
 
 {% include quiz.html id="element-2"
    question="Can you mutate a React element after creating it?"
-   options="A|Yes, you mutate its props directly;B|No — React elements are immutable. To &quot;change&quot; one you re-render, producing a new element, and the reconciler figures out the minimum DOM update"
+   options="A|Yes, you mutate its props directly;;B|No — React elements are immutable. To &quot;change&quot; one you re-render, producing a new element, and the reconciler figures out the minimum DOM update"
    correct="B"
    explanation="Immutability is what enables efficient diffing. If you tried to mutate props, React wouldn't know what changed and couldn't apply the right updates." %}
 
 {% include quiz.html id="element-3"
    question="Which is NOT a custom element state in Web Components?"
-   options="A|undefined (not yet defined);B|failed (upgrade threw);C|constructed (element upgraded);D|purged (destroyed) — there is no such state"
+   options="A|undefined (not yet defined);;B|failed (upgrade threw);;C|constructed (element upgraded);;D|purged (destroyed) — there is no such state"
    correct="D"
    explanation="Standard states are undefined, failed, uncustomized, custom (sometimes called &quot;constructed&quot;). &quot;Purged&quot; is not in the spec — removal happens via disconnectedCallback." %}
 
 {% include quiz.html id="element-4"
    question="How does the Virtual DOM use elements to improve performance?"
-   options="A|It skips the DOM entirely;B|It keeps a lightweight in-memory tree of elements, diffs the previous and next trees on update, and applies only the minimum set of real DOM mutations — amortising the cost of changes;C|It renders everything in a Web Worker;D|It disables reflow"
+   options="A|It skips the DOM entirely;;B|It keeps a lightweight in-memory tree of elements, diffs the previous and next trees on update, and applies only the minimum set of real DOM mutations — amortising the cost of changes;;C|It renders everything in a Web Worker;;D|It disables reflow"
    correct="B"
    explanation="Real DOM mutations are expensive. By diffing cheap JS object trees first and batching writes, React (and similar libraries) avoid re-laying out the whole page on every state change." %}
 
 {% include quiz.html id="element-5"
    question="When is it appropriate to use a ref to access a DOM element in React?"
-   options="A|Whenever you would write jQuery;B|Only for imperative operations that React can't express declaratively: focus/selection, measuring layout, integrating 3rd-party non-React libraries, and media playback control;C|For any state a component owns;D|Never — refs are deprecated"
+   options="A|Whenever you would write jQuery;;B|Only for imperative operations that React can't express declaratively: focus/selection, measuring layout, integrating 3rd-party non-React libraries, and media playback control;;C|For any state a component owns;;D|Never — refs are deprecated"
    correct="B"
    explanation="Refs are an escape hatch. Reach for them when you genuinely need the underlying DOM node; don't use them to bypass state." %}
 

--- a/docs/ui/events.md
+++ b/docs/ui/events.md
@@ -534,31 +534,31 @@ Each approach reflects the framework's philosophy: React and Vue integrate event
 
 {% include quiz.html id="events-1"
    question="What is an HTML element event?"
-   options="A|A CSS pseudo-class;B|A server-side hook in the HTTP protocol;C|A signal the browser fires when something happens on a page (click, input change, load, keypress, etc.) that JS can listen to and respond to;D|A React lifecycle method"
+   options="A|A CSS pseudo-class;;B|A server-side hook in the HTTP protocol;;C|A signal the browser fires when something happens on a page (click, input change, load, keypress, etc.) that JS can listen to and respond to;;D|A React lifecycle method"
    correct="C"
    explanation="Events are how the DOM surfaces user and system activity. JS subscribes via addEventListener or framework-specific binding to react to them." %}
 
 {% include quiz.html id="events-2"
    question="Which is the most flexible way to attach an event handler in plain HTML/JS?"
-   options="A|Inline onclick attribute;B|Assigning element.onclick = fn, which overwrites any existing handler;C|element.addEventListener('click', fn), which supports multiple handlers and easy removal via removeEventListener;D|jQuery"
+   options="A|Inline onclick attribute;;B|Assigning element.onclick = fn, which overwrites any existing handler;;C|element.addEventListener('click', fn), which supports multiple handlers and easy removal via removeEventListener;;D|jQuery"
    correct="C"
    explanation="addEventListener lets you register multiple handlers, choose capture vs bubble, opt into passive/once, and cleanly remove listeners — properties on the element can only hold a single handler." %}
 
 {% include quiz.html id="events-3"
    question="What is the difference between event capturing and event bubbling?"
-   options="A|They are the same thing;B|Capturing flows from the window DOWN to the target; bubbling flows from the target UP to the window. Listeners run during both phases;C|Capturing applies only to keyboard events;D|Bubbling is disabled by default"
+   options="A|They are the same thing;;B|Capturing flows from the window DOWN to the target; bubbling flows from the target UP to the window. Listeners run during both phases;;C|Capturing applies only to keyboard events;;D|Bubbling is disabled by default"
    correct="B"
    explanation="The event travels in three phases: capture (top-down), target, then bubble (bottom-up). addEventListener defaults to bubble phase; pass `{ capture: true }` to run during capture." %}
 
 {% include quiz.html id="events-4"
    question="What does React's SyntheticEvent give you over a raw DOM event?"
-   options="A|Nothing — it's a pass-through;B|A cross-browser normalized wrapper with consistent properties, event pooling (historically), and integration with React's update batching;C|It replaces addEventListener for non-React code too;D|It disables preventDefault"
+   options="A|Nothing — it's a pass-through;;B|A cross-browser normalized wrapper with consistent properties, event pooling (historically), and integration with React's update batching;;C|It replaces addEventListener for non-React code too;;D|It disables preventDefault"
    correct="B"
    explanation="SyntheticEvent smooths over browser differences and ties event dispatching into React's rendering model — that's why you write `onClick` in camelCase and pass a function, not a string." %}
 
 {% include quiz.html id="events-5"
    question="When attaching a scroll or touchmove listener, why is `{ passive: true }` important?"
-   options="A|It prevents the event from firing twice;B|It tells the browser the handler will not call preventDefault, so it can start scrolling immediately without waiting for JS — critical for 60fps scrolling on mobile;C|It makes the listener run in a Web Worker;D|It automatically removes the listener after one call"
+   options="A|It prevents the event from firing twice;;B|It tells the browser the handler will not call preventDefault, so it can start scrolling immediately without waiting for JS — critical for 60fps scrolling on mobile;;C|It makes the listener run in a Web Worker;;D|It automatically removes the listener after one call"
    correct="B"
    explanation="Passive listeners unblock the main thread's scroll handling. Non-passive scroll/touchmove handlers force the browser to wait for JS before scrolling, causing jank." %}
 

--- a/docs/ui/molecule.md
+++ b/docs/ui/molecule.md
@@ -540,31 +540,31 @@ const FormField = ({ label, value, onChange, error, required }) => (
 
 {% include quiz.html id="molecule-1"
    question="What is the primary difference between an atom and a molecule in Atomic Design?"
-   options="A|Atoms render, molecules manage state;B|Atoms are single-purpose indivisible units, molecules are purposeful compositions of multiple atoms that form a functional UI pattern;C|Atoms are styled, molecules are unstyled;D|Molecules always fetch data, atoms never do"
+   options="A|Atoms render, molecules manage state;;B|Atoms are single-purpose indivisible units, molecules are purposeful compositions of multiple atoms that form a functional UI pattern;;C|Atoms are styled, molecules are unstyled;;D|Molecules always fetch data, atoms never do"
    correct="B"
    explanation="Atoms (Button, Input, Icon) can't be broken down further without losing meaning. A molecule (SearchBar = Input + Button + Icon) assembles atoms into a reusable pattern with a cohesive purpose." %}
 
 {% include quiz.html id="molecule-2"
    question="Which of these belongs inside a molecule, and which does NOT?"
-   options="A|UI-only state like dropdown open/closed is fine; data fetching and business logic do NOT belong;B|Everything belongs — molecules should be self-sufficient;C|Only pure markup; not even local UI state is allowed"
+   options="A|UI-only state like dropdown open/closed is fine; data fetching and business logic do NOT belong;;B|Everything belongs — molecules should be self-sufficient;;C|Only pure markup; not even local UI state is allowed"
    correct="A"
    explanation="Molecules can own composition logic and local UI state (e.g., menu open/closed). Data fetching, global state mutations, and routing belong in containers or higher-level components." %}
 
 {% include quiz.html id="molecule-3"
    question="When should you extract a molecule instead of just composing atoms inline?"
-   options="A|As soon as two atoms are placed next to each other;B|Only when the product manager asks;C|When the same atom composition repeats across the app or encodes a cohesive, consistent pattern;D|Only for forms"
+   options="A|As soon as two atoms are placed next to each other;;B|Only when the product manager asks;;C|When the same atom composition repeats across the app or encodes a cohesive, consistent pattern;;D|Only for forms"
    correct="C"
    explanation="A molecule earns its keep when the pattern repeats and has a single purpose (FormField, SearchBar, NotificationItem). Extracting once-used combinations just adds files for no reuse gain." %}
 
 {% include quiz.html id="molecule-4"
    question="Can a molecule contain other molecules?"
-   options="A|No, molecules may only contain atoms;B|Yes — nested molecules (e.g. Card -> CardHeader) are encouraged when each has independent reuse value, but deep nesting usually signals an organism"
+   options="A|No, molecules may only contain atoms;;B|Yes — nested molecules (e.g. Card -> CardHeader) are encouraged when each has independent reuse value, but deep nesting usually signals an organism"
    correct="B"
    explanation="Hierarchical composition (Card -> CardHeader -> Image/Title/Badge atoms) is a core part of the methodology. Push to an organism when nesting stops being about cohesion and starts managing multiple concerns." %}
 
 {% include quiz.html id="molecule-5"
    question="What's the best strategy for molecule props?"
-   options="A|Expose every possible atom prop so nothing is hidden;B|Expose only what varies, accept interaction callbacks, and use rest-props spread onto the inner atom for flexibility;C|Accept the whole Redux state as a prop so the molecule is self-contained"
+   options="A|Expose every possible atom prop so nothing is hidden;;B|Expose only what varies, accept interaction callbacks, and use rest-props spread onto the inner atom for flexibility;;C|Accept the whole Redux state as a prop so the molecule is self-contained"
    correct="B"
    explanation="Well-scoped props (label, value, onChange, error, variant) plus a rest-spread onto the core atom keep molecules flexible without prop explosion. Passing global state tightly couples the molecule to your store." %}
 

--- a/docs/ui/organism.md
+++ b/docs/ui/organism.md
@@ -604,31 +604,31 @@ const DashboardPanel = ({ title, subtitle, actions, children }) => (
 
 {% include quiz.html id="organism-1"
    question="What distinguishes an organism from a molecule in Atomic Design?"
-   options="A|Organisms must use TypeScript;B|Organisms are complex, self-contained UI sections composed of multiple molecules (and atoms) that represent a meaningful region — header, product card, comment thread — whereas molecules are smaller single-purpose compositions;C|There is no difference;D|Organisms render on the server"
+   options="A|Organisms must use TypeScript;;B|Organisms are complex, self-contained UI sections composed of multiple molecules (and atoms) that represent a meaningful region — header, product card, comment thread — whereas molecules are smaller single-purpose compositions;;C|There is no difference;;D|Organisms render on the server"
    correct="B"
    explanation="If a component is orchestrating several molecules to form a distinct region of the page, it has graduated to organism level." %}
 
 {% include quiz.html id="organism-2"
    question="Should organisms contain business logic and data fetching, or stay purely presentational?"
-   options="A|They should fetch data directly for convenience;B|Organisms can own UI-level state (dropdown open/closed, filter selection) but business logic, data fetching, and global state mutations belong in containers — the container wires a fetched data shape into the organism via props;C|Organisms must be stateless;D|They replace Redux"
+   options="A|They should fetch data directly for convenience;;B|Organisms can own UI-level state (dropdown open/closed, filter selection) but business logic, data fetching, and global state mutations belong in containers — the container wires a fetched data shape into the organism via props;;C|Organisms must be stateless;;D|They replace Redux"
    correct="B"
    explanation="Keeping organisms presentational makes them reusable across pages and testable in Storybook. The container/organism split is how large apps scale." %}
 
 {% include quiz.html id="organism-3"
    question="When should you create a new organism rather than extending an existing one?"
-   options="A|When the purpose of the UI section is meaningfully different from any existing organism, when reuse of the current organism would require many conditional props/branches, or when the responsibilities differ;B|Every time a designer changes a color;C|Never — always extend;D|When you run out of file names"
+   options="A|When the purpose of the UI section is meaningfully different from any existing organism, when reuse of the current organism would require many conditional props/branches, or when the responsibilities differ;;B|Every time a designer changes a color;;C|Never — always extend;;D|When you run out of file names"
    correct="A"
    explanation="Forking into a new organism beats piling variant props onto the old one past the point where the code reads as &quot;two different things pretending to be one.&quot;" %}
 
 {% include quiz.html id="organism-4"
    question="How should organisms handle responsive design compared to molecules?"
-   options="A|They shouldn't — responsive only belongs at the page level;B|Organisms often coordinate layout across multiple molecules, so they're a natural place for container queries / breakpoint-driven layout changes; molecules typically only need to handle their own internal responsive behavior;C|Only atoms handle responsive;D|Responsive design is legacy"
+   options="A|They shouldn't — responsive only belongs at the page level;;B|Organisms often coordinate layout across multiple molecules, so they're a natural place for container queries / breakpoint-driven layout changes; molecules typically only need to handle their own internal responsive behavior;;C|Only atoms handle responsive;;D|Responsive design is legacy"
    correct="B"
    explanation="Molecules worry about their internal flex/grid. Organisms decide when the whole region rearranges (side-by-side vs stacked, nav collapsing to hamburger)." %}
 
 {% include quiz.html id="organism-5"
    question="What is the typical relationship between organisms and state management (Redux, Context, etc.)?"
-   options="A|Organisms are the only layer allowed to subscribe to the store;B|Organisms stay pure and receive what they need via props; a surrounding container subscribes to the store, derives data with selectors, and passes it down — keeping the organism decoupled from the specific store tech;C|Organisms must import the Redux store directly;D|State managers were deprecated"
+   options="A|Organisms are the only layer allowed to subscribe to the store;;B|Organisms stay pure and receive what they need via props; a surrounding container subscribes to the store, derives data with selectors, and passes it down — keeping the organism decoupled from the specific store tech;;C|Organisms must import the Redux store directly;;D|State managers were deprecated"
    correct="B"
    explanation="Subscribing inside organisms ties their reuse to one specific app. Pushing subscriptions up to a container lets the same organism live in Storybook, tests, or a different app without rewiring." %}
 

--- a/docs/ui/props.md
+++ b/docs/ui/props.md
@@ -485,33 +485,33 @@ const Button: React.FC<ButtonProps> = ({
 
 {% include quiz.html id="props-1"
    question="What happens if you mutate a prop inside a component?"
-   options="A|Nothing — it works fine;B|In React (strict mode) it's a bug: props are expected to be immutable from the component's perspective. Mutating them breaks the one-way data flow, won't trigger re-renders reliably, and can silently corrupt the parent's state;C|The framework auto-saves the mutation to the parent;D|It is encouraged"
+   options="A|Nothing — it works fine;;B|In React (strict mode) it's a bug: props are expected to be immutable from the component's perspective. Mutating them breaks the one-way data flow, won't trigger re-renders reliably, and can silently corrupt the parent's state;;C|The framework auto-saves the mutation to the parent;;D|It is encouraged"
    correct="B"
    explanation="Treat props as read-only. If you need to derive or transform, copy into local state or use a memoized derivation. Mutating is almost always a bug." %}
 
 {% include quiz.html id="props-2"
    question="In Web Components, what's the difference between an attribute and a property?"
-   options="A|None — they're synonyms;B|Attributes are always strings (set in HTML or via setAttribute); properties are typed JS fields on the element instance. Libraries like Lit commonly reflect certain properties to attributes for interop, but complex values (objects, arrays, functions) should only be passed via properties;C|Properties only work server-side;D|Attributes are faster to read"
+   options="A|None — they're synonyms;;B|Attributes are always strings (set in HTML or via setAttribute); properties are typed JS fields on the element instance. Libraries like Lit commonly reflect certain properties to attributes for interop, but complex values (objects, arrays, functions) should only be passed via properties;;C|Properties only work server-side;;D|Attributes are faster to read"
    correct="B"
    explanation="This is the big web-components gotcha: if you need to pass an object or a function, use the property. Attributes stringify everything." %}
 
 {% include quiz.html id="props-3"
    question="Should you pass individual values or a whole object as a prop?"
-   options="A|Always pass the whole object — fewer props;B|Prefer individual, explicit props for clarity and targeted memoization; pass an object only when it's genuinely cohesive (e.g. a user record whose fields travel together) — and remember the consumer then re-renders whenever any field on the object changes;C|Always spread the entire store;D|It doesn't matter"
+   options="A|Always pass the whole object — fewer props;;B|Prefer individual, explicit props for clarity and targeted memoization; pass an object only when it's genuinely cohesive (e.g. a user record whose fields travel together) — and remember the consumer then re-renders whenever any field on the object changes;;C|Always spread the entire store;;D|It doesn't matter"
    correct="B"
    explanation="Explicit props make components self-documenting and enable precise memoization. Pass objects when the fields are conceptually one thing, not as a shortcut." %}
 
 {% include quiz.html id="props-4"
    question="What's an effective modern approach to type-checking props in a React codebase?"
-   options="A|Ship no types and hope;B|TypeScript interfaces/types on component props give compile-time checking with editor completion; PropTypes can still add runtime validation in plain-JS projects but is largely superseded by TS in new work;C|JSDoc only;D|Rely on eslint alone"
+   options="A|Ship no types and hope;;B|TypeScript interfaces/types on component props give compile-time checking with editor completion; PropTypes can still add runtime validation in plain-JS projects but is largely superseded by TS in new work;;C|JSDoc only;;D|Rely on eslint alone"
    correct="B"
    explanation="TS catches misuse at the call site before the code ships. PropTypes are useful runtime belt-and-braces in JS-only codebases but React 19 has dropped the auto-extraction treatment they used to get." %}
 
 {% include quiz.html id="props-5"
    question="What is the React `children` prop for?"
-   options="A|It is deprecated;B|It lets a parent pass JSX markup into a slot inside the child component, enabling composition patterns like layouts, wrappers, and customisable containers without reinventing a prop API per case;C|It stores animation frames;D|It is only used for tables"
+   options="A|It is deprecated;;B|It lets a parent pass JSX markup into a slot inside the child component, enabling composition patterns like layouts, wrappers, and customisable containers without reinventing a prop API per case;;C|It stores animation frames;;D|It is only used for tables"
    correct="B"
-   explanation="&lt;Card&gt;&lt;p&gt;Hello&lt;/p&gt;&lt;/Card&gt; passes the &lt;p&gt; as `props.children` so Card can render it in a slot. Vue/WC use &lt;slot&gt;; Angular uses ng-content — same idea." %}
+   explanation="<Card><p>Hello</p></Card> passes the <p> as `props.children` so Card can render it in a slot. Vue/WC use <slot>; Angular uses ng-content — same idea." %}
 
 ## References
 

--- a/docs/ui/rwd.md
+++ b/docs/ui/rwd.md
@@ -283,33 +283,33 @@ h1 {
 
 {% include quiz.html id="rwd-1"
    question="What's the practical difference between mobile-first and desktop-first responsive CSS?"
-   options="A|Mobile-first starts with the smallest layout and uses min-width media queries to layer on complexity as the viewport grows; desktop-first starts with the full layout and uses max-width queries to strip back features. Mobile-first generally ships less default CSS and better matches progressive-enhancement thinking;B|Mobile-first only works on iOS;C|Desktop-first is faster;D|They produce identical CSS"
+   options="A|Mobile-first starts with the smallest layout and uses min-width media queries to layer on complexity as the viewport grows; desktop-first starts with the full layout and uses max-width queries to strip back features. Mobile-first generally ships less default CSS and better matches progressive-enhancement thinking;;B|Mobile-first only works on iOS;;C|Desktop-first is faster;;D|They produce identical CSS"
    correct="A"
    explanation="Mobile-first makes the smallest-screen experience the baseline, which tends to force better hierarchy decisions and lighter initial styles." %}
 
 {% include quiz.html id="rwd-2"
    question="How should you choose breakpoints?"
-   options="A|Copy Bootstrap's values and never think about it again;B|Let the content and layout drive the breakpoints — add a breakpoint wherever the current layout starts to break, not at fixed device widths. Device-specific breakpoints age badly as new devices appear;C|One breakpoint per known device;D|Only one breakpoint at 768px"
+   options="A|Copy Bootstrap's values and never think about it again;;B|Let the content and layout drive the breakpoints — add a breakpoint wherever the current layout starts to break, not at fixed device widths. Device-specific breakpoints age badly as new devices appear;;C|One breakpoint per known device;;D|Only one breakpoint at 768px"
    correct="B"
    explanation="Fixed-device breakpoints age with the hardware. Content-driven breakpoints stay correct." %}
 
 {% include quiz.html id="rwd-3"
    question="How do you implement fluid typography that scales smoothly between viewport sizes?"
-   options="A|Hard-code font-size per breakpoint;B|Use clamp(min, preferred, max) with a vw-based preferred value, e.g. font-size: clamp(1rem, 0.5rem + 1vw, 1.5rem) — the browser interpolates between min and max as the viewport grows, with bounds for accessibility;C|Use JavaScript to resize on scroll;D|Only rely on rem units"
+   options="A|Hard-code font-size per breakpoint;;B|Use clamp(min, preferred, max) with a vw-based preferred value, e.g. font-size: clamp(1rem, 0.5rem + 1vw, 1.5rem) — the browser interpolates between min and max as the viewport grows, with bounds for accessibility;;C|Use JavaScript to resize on scroll;;D|Only rely on rem units"
    correct="B"
    explanation="clamp() gives you fluid scaling with explicit lower/upper bounds, avoiding unreadably small or huge text on extreme viewports." %}
 
 {% include quiz.html id="rwd-4"
    question="What are container queries and how do they complement media queries?"
-   options="A|They are the same as media queries;B|Container queries let a component restyle based on the size of its containing element rather than the viewport, so a card can render differently in a narrow sidebar vs a wide hero without the page knowing — exactly what atomic-design components need;C|They only work on the body element;D|They are deprecated"
+   options="A|They are the same as media queries;;B|Container queries let a component restyle based on the size of its containing element rather than the viewport, so a card can render differently in a narrow sidebar vs a wide hero without the page knowing — exactly what atomic-design components need;;C|They only work on the body element;;D|They are deprecated"
    correct="B"
    explanation="Media queries know about the viewport. Container queries finally give components true component-level responsiveness." %}
 
 {% include quiz.html id="rwd-5"
    question="What's the right way to serve responsive images?"
-   options="A|Always a single full-resolution image — browsers handle scaling;B|Use &lt;img srcset&gt; with sizes, or &lt;picture&gt; with &lt;source&gt; for art direction, so the browser downloads the best-sized image for the viewport and pixel density — plus loading=&quot;lazy&quot; for below-the-fold images;C|Only JPEG;D|Base64-encode everything"
+   options="A|Always a single full-resolution image — browsers handle scaling;;B|Use <img srcset> with sizes, or <picture> with <source> for art direction, so the browser downloads the best-sized image for the viewport and pixel density — plus loading=&quot;lazy&quot; for below-the-fold images;;C|Only JPEG;;D|Base64-encode everything"
    correct="B"
-   explanation="srcset/sizes lets the browser pick the best bitmap; &lt;picture&gt; adds art-direction swaps. Combining with lazy loading and WebP/AVIF modern formats delivers the biggest perf wins." %}
+   explanation="srcset/sizes lets the browser pick the best bitmap; <picture> adds art-direction swaps. Combining with lazy loading and WebP/AVIF modern formats delivers the biggest perf wins." %}
 
 ## References
 

--- a/docs/ui/skeleton.md
+++ b/docs/ui/skeleton.md
@@ -456,31 +456,31 @@ const UserProfile = ({ userId }) => {
 
 {% include quiz.html id="skeleton-1"
    question="Why do skeleton screens feel faster than traditional loading spinners?"
-   options="A|They literally fetch faster;B|They give the user a perceived structural preview of the content, so the wait feels like the content is almost here rather than an abstract delay — perceived performance, not actual latency;C|Skeletons disable caching;D|Spinners are technically slower to render"
+   options="A|They literally fetch faster;;B|They give the user a perceived structural preview of the content, so the wait feels like the content is almost here rather than an abstract delay — perceived performance, not actual latency;;C|Skeletons disable caching;;D|Spinners are technically slower to render"
    correct="B"
    explanation="Actual network time is unchanged, but a shape that matches the final layout keeps users anchored and reduces the feeling of being stuck." %}
 
 {% include quiz.html id="skeleton-2"
    question="Should a skeleton exactly match the final rendered content?"
-   options="A|Yes — pixel-perfect or it's misleading;B|It should roughly match structure and rhythm (rows, avatar+text, image placeholders) so there's no jarring layout shift when real content arrives, but pixel-perfect matching is unnecessary and brittle;C|No — it should be completely generic;D|Skeletons should show actual content"
+   options="A|Yes — pixel-perfect or it's misleading;;B|It should roughly match structure and rhythm (rows, avatar+text, image placeholders) so there's no jarring layout shift when real content arrives, but pixel-perfect matching is unnecessary and brittle;;C|No — it should be completely generic;;D|Skeletons should show actual content"
    correct="B"
    explanation="The goal is preventing CLS and setting expectations. Obsessing over pixel parity creates maintenance burden and couples the skeleton to details that change often." %}
 
 {% include quiz.html id="skeleton-3"
    question="When should you NOT use a skeleton screen?"
-   options="A|For very short loads (&lt; ~300ms — the flash is worse than nothing), for error states (use an error UI), or for indeterminate background work where a subtle spinner/progress bar is the right signal;B|Never — skeletons are always correct;C|Only on mobile;D|Only when JavaScript is disabled"
+   options="A|For very short loads (< ~300ms — the flash is worse than nothing), for error states (use an error UI), or for indeterminate background work where a subtle spinner/progress bar is the right signal;;B|Never — skeletons are always correct;;C|Only on mobile;;D|Only when JavaScript is disabled"
    correct="A"
    explanation="Skeletons shine for 300ms–few-seconds content loads. Sub-300ms shows a flicker; errors want actionable messaging; background work wants progress indication." %}
 
 {% include quiz.html id="skeleton-4"
    question="How do you implement a skeleton shimmer animation without hurting performance?"
-   options="A|JavaScript setInterval that repaints every 16ms;B|A CSS background gradient animated with transform or background-position, using will-change sparingly and preferring GPU-accelerated properties — no layout thrash, no JS;C|A hand-drawn GIF;D|Animate opacity of hundreds of individual pixels"
+   options="A|JavaScript setInterval that repaints every 16ms;;B|A CSS background gradient animated with transform or background-position, using will-change sparingly and preferring GPU-accelerated properties — no layout thrash, no JS;;C|A hand-drawn GIF;;D|Animate opacity of hundreds of individual pixels"
    correct="B"
    explanation="CSS animation on transform / background-position stays on the compositor thread. JS loops or layout-affecting animations cause unnecessary main-thread work." %}
 
 {% include quiz.html id="skeleton-5"
    question="How should skeletons handle responsive layouts?"
-   options="A|Serve one static skeleton and accept the layout shift;B|Build the skeleton out of the same flex/grid layout primitives as the real component so it naturally follows breakpoints and container queries — that keeps the reserved space accurate at every viewport and avoids CLS when real content lands;C|Only render skeletons on desktop;D|Use JS to compute widths at runtime"
+   options="A|Serve one static skeleton and accept the layout shift;;B|Build the skeleton out of the same flex/grid layout primitives as the real component so it naturally follows breakpoints and container queries — that keeps the reserved space accurate at every viewport and avoids CLS when real content lands;;C|Only render skeletons on desktop;;D|Use JS to compute widths at runtime"
    correct="B"
    explanation="If the skeleton uses the same layout system as the real UI, it mirrors the real layout at every breakpoint automatically." %}
 

--- a/docs/ui/story.md
+++ b/docs/ui/story.md
@@ -639,31 +639,31 @@ export default {
 
 {% include quiz.html id="story-1"
    question="What's the practical difference between args and argTypes in Storybook CSF?"
-   options="A|They are synonyms;B|args are the actual values you pass to a story's component props (what renders), while argTypes declare the shape/controls/descriptions for those args (how they appear in the Controls panel, docs, and which editor widget is used);C|argTypes are only for TypeScript;D|args are deprecated"
+   options="A|They are synonyms;;B|args are the actual values you pass to a story's component props (what renders), while argTypes declare the shape/controls/descriptions for those args (how they appear in the Controls panel, docs, and which editor widget is used);;C|argTypes are only for TypeScript;;D|args are deprecated"
    correct="B"
    explanation="You can override args per story. argTypes configure the experience around those args — control type, options, descriptions, categories." %}
 
 {% include quiz.html id="story-2"
    question="What's the modern, framework-friendly way to test user interactions in a story?"
-   options="A|Render manually with your test runner and ignore Storybook;B|Write a `play` function that uses @storybook/test (userEvent, fireEvent, expect) — it runs automatically in Storybook's interactions addon and also in CI via the test-runner, giving you one source of truth for interaction tests and visual examples;C|Copy the tests into a separate .test.js file only;D|Rely on manual QA"
+   options="A|Render manually with your test runner and ignore Storybook;;B|Write a `play` function that uses @storybook/test (userEvent, fireEvent, expect) — it runs automatically in Storybook's interactions addon and also in CI via the test-runner, giving you one source of truth for interaction tests and visual examples;;C|Copy the tests into a separate .test.js file only;;D|Rely on manual QA"
    correct="B"
    explanation="`play` functions turn stories into executable interaction tests, and running them in the test-runner catches regressions in CI." %}
 
 {% include quiz.html id="story-3"
    question="When should you reach for a decorator vs a parameter?"
-   options="A|Always use parameters;B|Decorators wrap stories in additional markup or context (ThemeProvider, Router, mock Redux store); parameters configure story/addon behavior (layout, backgrounds, a11y options, docs overrides). Use decorators for wiring, parameters for configuration;C|Parameters are only for Vue;D|They are interchangeable"
+   options="A|Always use parameters;;B|Decorators wrap stories in additional markup or context (ThemeProvider, Router, mock Redux store); parameters configure story/addon behavior (layout, backgrounds, a11y options, docs overrides). Use decorators for wiring, parameters for configuration;;C|Parameters are only for Vue;;D|They are interchangeable"
    correct="B"
    explanation="If it needs to render around the component, it's a decorator. If it's knobs for Storybook itself, it's a parameter." %}
 
 {% include quiz.html id="story-4"
    question="How can you share setup across multiple stories of different components?"
-   options="A|Copy-paste the setup into each story file;B|Export reusable decorators and args/argTypes from a shared module and apply them at the story, meta, or `.storybook/preview` level — preview-level applies to everything, meta-level to one component, story-level to one story;C|Use localStorage;D|Storybook doesn't support sharing"
+   options="A|Copy-paste the setup into each story file;;B|Export reusable decorators and args/argTypes from a shared module and apply them at the story, meta, or `.storybook/preview` level — preview-level applies to everything, meta-level to one component, story-level to one story;;C|Use localStorage;;D|Storybook doesn't support sharing"
    correct="B"
    explanation="Storybook has three scopes — global (preview), per-component (meta), per-story — for decorators, parameters, and args. Put shared wiring at the highest scope that applies." %}
 
 {% include quiz.html id="story-5"
    question="How should stories be organised for a large component library?"
-   options="A|Flat — all stories at the root;B|Follow the atomic-design hierarchy or your domain structure in story titles (&quot;Atoms/Button&quot;, &quot;Molecules/FormField&quot;, &quot;Pages/Dashboard&quot;) so the Storybook sidebar mirrors the component hierarchy and stays navigable as the library grows;C|One file per design system version;D|Alphabetical only"
+   options="A|Flat — all stories at the root;;B|Follow the atomic-design hierarchy or your domain structure in story titles (&quot;Atoms/Button&quot;, &quot;Molecules/FormField&quot;, &quot;Pages/Dashboard&quot;) so the Storybook sidebar mirrors the component hierarchy and stays navigable as the library grows;;C|One file per design system version;;D|Alphabetical only"
    correct="B"
    explanation="Titles are just strings with `/` as a separator, which Storybook renders as a tree. Keep the tree shallow but meaningful — Atoms/Molecules/Organisms/Pages is a proven default." %}
 

--- a/docs/ui/theme.md
+++ b/docs/ui/theme.md
@@ -586,33 +586,33 @@ initTheme();
 
 {% include quiz.html id="theme-1"
    question="What are design tokens and why are they preferable to hard-coded CSS values?"
-   options="A|They are the same as CSS variables in every way;B|Design tokens are named, platform-agnostic style primitives (color.brand.primary, space.md, type.heading.lg) defined once and shared across design tools and code — enabling consistency, easy theme changes, platform export (web/iOS/Android), and a shared vocabulary between design and engineering;C|Tokens are only for enterprise apps;D|Tokens replace the CSS cascade"
+   options="A|They are the same as CSS variables in every way;;B|Design tokens are named, platform-agnostic style primitives (color.brand.primary, space.md, type.heading.lg) defined once and shared across design tools and code — enabling consistency, easy theme changes, platform export (web/iOS/Android), and a shared vocabulary between design and engineering;;C|Tokens are only for enterprise apps;;D|Tokens replace the CSS cascade"
    correct="B"
    explanation="Hard-coded values scatter branding decisions everywhere. Tokens centralise them and make rebrands / dark mode / white-labelling a data change rather than a code change." %}
 
 {% include quiz.html id="theme-2"
    question="How do CSS custom properties differ from Sass/Less variables for theming?"
-   options="A|They are identical;B|Sass/Less variables are compile-time constants (fixed after build). CSS custom properties are runtime values that cascade, can be overridden by scope, and can be changed dynamically — which is why modern theming (and dark mode) relies on custom properties;C|Sass variables work in older browsers better;D|Custom properties cannot be nested"
+   options="A|They are identical;;B|Sass/Less variables are compile-time constants (fixed after build). CSS custom properties are runtime values that cascade, can be overridden by scope, and can be changed dynamically — which is why modern theming (and dark mode) relies on custom properties;;C|Sass variables work in older browsers better;;D|Custom properties cannot be nested"
    correct="B"
    explanation="You can't switch Sass variables at runtime — they've already been compiled away. CSS custom properties live in the CSSOM and can be swapped by updating a class on the root element." %}
 
 {% include quiz.html id="theme-3"
    question="What's a robust way to implement dark mode?"
-   options="A|Hard-code a separate stylesheet per theme and swap the &lt;link&gt; tag;B|Define theme tokens as CSS custom properties on :root, override them under .dark (or [data-theme=&quot;dark&quot;]) and @media (prefers-color-scheme: dark) for the auto default, and let the rest of the CSS consume var(--...) — no component code needs to change;C|Use !important everywhere;D|Only inline styles"
+   options="A|Hard-code a separate stylesheet per theme and swap the <link> tag;;B|Define theme tokens as CSS custom properties on :root, override them under .dark (or [data-theme=&quot;dark&quot;]) and @media (prefers-color-scheme: dark) for the auto default, and let the rest of the CSS consume var(--...) — no component code needs to change;;C|Use !important everywhere;;D|Only inline styles"
    correct="B"
    explanation="A single source of truth (tokens) plus a root-level theme class means the whole app flips with one attribute toggle, and prefers-color-scheme gives users system-default support for free." %}
 
 {% include quiz.html id="theme-4"
    question="Should themes be global or component-scoped?"
-   options="A|Always component-scoped — globals are evil;B|Typically global tokens at :root for consistency, with the option of scoped theme overrides on a subtree (e.g. a dark card on a light page) by re-declaring the same custom properties under a wrapper. The same tokens are consumed either way;C|Always global — scoped theming doesn't work;D|Themes must be per-component file"
+   options="A|Always component-scoped — globals are evil;;B|Typically global tokens at :root for consistency, with the option of scoped theme overrides on a subtree (e.g. a dark card on a light page) by re-declaring the same custom properties under a wrapper. The same tokens are consumed either way;;C|Always global — scoped theming doesn't work;;D|Themes must be per-component file"
    correct="B"
    explanation="Custom properties cascade, so scoped overrides are trivial. Global defaults keep the whole app coherent; scoped overrides handle the one-offs." %}
 
 {% include quiz.html id="theme-5"
    question="How do you handle theme-specific images or icons (e.g. different logos for light/dark)?"
-   options="A|Hide/show two &lt;img&gt; tags with CSS;B|Use &lt;picture&gt; with &lt;source media=&quot;(prefers-color-scheme: dark)&quot;&gt; so the browser picks the right asset; or use SVG with currentColor so a single asset recolors via a CSS variable;C|Only use one image regardless of theme;D|Emit two entire CSS files"
+   options="A|Hide/show two <img> tags with CSS;;B|Use <picture> with <source media=&quot;(prefers-color-scheme: dark)&quot;> so the browser picks the right asset; or use SVG with currentColor so a single asset recolors via a CSS variable;;C|Only use one image regardless of theme;;D|Emit two entire CSS files"
    correct="B"
-   explanation="&lt;picture&gt; + media queries fetches only the variant you need. currentColor on SVG icons is the lightest solution when the only change is tint." %}
+   explanation="<picture> + media queries fetches only the variant you need. currentColor on SVG icons is the lightest solution when the only change is tint." %}
 
 ## References
 - [1] https://blog.hubspot.com/website/css-frameworks


### PR DESCRIPTION
## Summary

Follow-up to #26. Three issues were reported in the rendered MCQs:

- Many options appeared **without their A/B/C/D prefix letter**
- Some options showed visible `&apos;` entities
- Some pages had options silently missing altogether

**Root cause:** the quiz include split `options=` on a single `;`. Every HTML entity ends with `;` (`&quot;`, `&amp;`, `&lt;`, `&gt;`, `&apos;`), and natural-language semicolons within one option text also produced false boundaries. Splitting there yielded fragments with no `letter|` prefix, which the template then rendered as unlabelled leftover text.

## Fixes

- `docs/_includes/quiz.html` — switch option separator from `;` to **`;;`** (HTML entities contain single `;`, so they no longer create false splits).
- Every existing `options="A|x;B|y"` across 35 MCQ-bearing docs rewritten to use `;;` between items. Boundary regex `;+(?=\s*[A-Z]\|)` used so the transform is idempotent.
- Replace `&apos;` with plain `'` in quiz fields — HTML attribute values delimited by `"..."` don't need `'` escaped, and some renderers showed `&apos;` literally.
- Unescape `&gt;` → `>` and `&lt;` → `<` inside quiz fields. Both are legal as literals inside double-quoted HTML attribute values, and keeping them as entities introduced more `;`-ending characters that paired with adjacent semicolons to form spurious `;;` boundaries.
- Manually rewrite one option in `attributes.md` that had `&quot;;` (entity + boundary) forming a residual `;;` false-positive.

## Verification (programmatic)

- 670 options across 35 docs
- 0 options missing a letter prefix
- 0 residual `&apos;` escapes
- 0 entity-adjacent `;;` boundaries

## Test plan
- [ ] Jekyll builds cleanly in CI
- [ ] Spot-check rendered MCQs on the deployed Pages site: each option shows its A/B/C/D letter badge, no stray `&apos;`/`&quot;`/`&gt;` entities visible, submit+reveal still works

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG