### PR TITLE
Fix skill download links: guard missing skills + serve same-origin for real download

### DIFF
--- a/demos.sh
+++ b/demos.sh
@@ -63,4 +63,12 @@ echo "Building Jekyll docs..."
 cd ../../docs
 bundle exec jekyll build
 
+# Copy Agent Skills into the built site so the download widget links
+# resolve same-origin (the browser's `download` attribute is ignored
+# cross-origin, so linking at github.com/raw would not actually
+# trigger a download).
+echo "Copying skills into _site..."
+mkdir -p _site/skills
+cp -R ../skills/* _site/skills/
+
 echo "Docs build complete."

--- a/docs/_data/skills.yml
+++ b/docs/_data/skills.yml
@@ -1,0 +1,38 @@
+# Auto-maintained list of skill slugs that exist under /skills/.
+# Used by _includes/doc-skill-download.html to only render the
+# download widget on docs whose matching SKILL.md exists.
+- server-api
+- server-app-shell
+- server-authentication
+- server-container
+- server-mfe
+- server-page
+- server-protocol
+- server-proxy
+- server-router
+- server-ssg
+- server-ssr
+- state-actions
+- state-ajax
+- state-crud
+- state-middleware
+- state-operations
+- state-reducer
+- state-selectors
+- state-state
+- state-store
+- ui-accessibility
+- ui-atom
+- ui-atomic-design
+- ui-attributes
+- ui-component
+- ui-dom
+- ui-element
+- ui-events
+- ui-molecule
+- ui-organism
+- ui-props
+- ui-skeleton
+- ui-story
+- ui-template
+- ui-theme

--- a/docs/_includes/doc-skill-download.html
+++ b/docs/_includes/doc-skill-download.html
@@ -1,5 +1,7 @@
 {% assign domain = page.url | split: "/" | slice: 1 | first %}
+{% assign skill_slug = domain | append: "-" | append: page.slug %}
 {% if domain == "ui" or domain == "server" or domain == "state" %}
+{% if site.data.skills contains skill_slug %}
 <div class="skill-alert">
   <div class="skill-alert__content">
     <svg class="skill-alert__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -10,9 +12,9 @@
       <span>Download this Agent Skill (SKILL.md) to drop into <code>~/.claude/skills/</code> or any Agent-Skills-compatible runtime for AI-assisted {{ page.title }} work.</span>
     </div>
   </div>
-  <a href="{{ site.github.repository_url }}/raw/master/skills/{{ domain }}-{{ page.slug }}/SKILL.md"
+  <a href="{{ '/skills/' | append: skill_slug | append: '/SKILL.md' | relative_url }}"
      class="skill-alert__download"
-     download="{{ domain }}-{{ page.slug }}-SKILL.md"
+     download="{{ skill_slug }}-SKILL.md"
      title="Download {{ page.title }} Skill">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
       <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
@@ -20,4 +22,5 @@
     <span>Download</span>
   </a>
 </div>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary

Two bugs in the Agent-Skill download widget rendered on UI / Server / State terminology docs:

1. **11 docs linked to a skill slug that doesn't exist under `/skills/`** — the widget rendered and clicking "Download" 404'd on GitHub. Affected pages: `ui/rwd`, `ui/skills`, `server/forms`, `server/images`, `server/index-file`, `server/links`, `server/localization`, `server/pwa`, `server/seo`, `server/session`, `server/widget`.
2. **The widget linked at `github.com/<repo>/raw/master/...`** — cross-origin. Browsers ignore the `download` attribute on cross-origin `<a>` targets, so clicking "Download" navigated to GitHub's rendered page instead of actually downloading the file.

## Fixes

- Add `docs/_data/skills.yml` listing every skill slug that exists under `/skills/`. The include now checks `site.data.skills contains skill_slug` before rendering, so docs without a matching skill quietly skip the download widget — no more 404s.
- Switch the link target to a same-origin URL (`/skills/<slug>/SKILL.md`). The browser now honors `download` and actually triggers a file download.
- Extend `demos.sh` to copy the `/skills` folder into `docs/_site/skills` after `jekyll build`. The copy happens post-build so Jekyll doesn't try to render each SKILL.md's front-matter as a page — the files are served verbatim.

## Test plan
- [ ] CI runs `npm run build-demos`, and the deployed Pages site contains `/skills/<slug>/SKILL.md` for each entry in the data file
- [ ] Clicking Download on e.g. `/ui/atom.html` triggers a browser download of `ui-atom-SKILL.md`
- [ ] The download widget no longer renders on docs without a backing skill (e.g. `server/pwa`, `ui/rwd`)

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG