### PR TITLE
Home: rename BEGIN heading to 'Begin with a harness'

### DIFF
--- a/docs/_includes/begin-boilerplate.html
+++ b/docs/_includes/begin-boilerplate.html
@@ -1,5 +1,5 @@
 <div class="begin-boilerplate">
-  <h2>BEGIN</h2>
+  <h2>Begin with a harness</h2>
   <div class="connected-steps">
     <div class="step">
       <img id="uiImg" src="{{ '/assets/img/brands/ui/chota.png' || | relative_url }}" />


### PR DESCRIPTION
## Summary

Rename the `<h2>` in the home-page boilerplate picker (`docs/_includes/begin-boilerplate.html`) from **BEGIN** → **Begin with a harness**. The single word wasn't landing the intent — visitors missed that the section is a starter-project picker. New heading matches the content below it (UI/server/state icons + `npx elegant ...` command).

## Test plan
- [ ] Check the rendered home page on the deployed site shows the new heading

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG