### PR TITLE
Home: add 'Context Engineer' and 'SDLC Harnessed' to typewriter rotation

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -14,6 +14,8 @@ function updateBoilerplate(e) {
 
 if (window.location.pathname === '/') {
   var textArray = [
+    "Context Engineer",
+    "SDLC Harnessed",
     "UI UX Oriented",
     "Framework Agnostic",
     "Atomic Design Ready",

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -14,7 +14,7 @@ function updateBoilerplate(e) {
 
 if (window.location.pathname === '/') {
   var textArray = [
-    "Context Engineer",
+    "Context Engineered",
     "SDLC Harnessed",
     "UI UX Oriented",
     "Framework Agnostic",


### PR DESCRIPTION
## Summary

Prepend two entries to the home-page typewriter rotation in `docs/assets/js/main.js`:

- `"Context Engineer"`
- `"SDLC Harnessed"`

They land the positioning ahead of the more tactical attributes already in the rotation (UI UX Oriented, Framework Agnostic, etc.).

## Test plan
- [ ] Check the home-page typewriter animation shows the two new phrases first in the cycle

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG