### PR TITLE
Docs: align terminology examples with templates via cross-framework code tabs

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -99,8 +99,7 @@ tabsNodes = document.querySelectorAll(".code-tabs");
 loop(tabsNodes, (tabsNode) => {
   nodes = tabsNode.querySelectorAll("p");
   if (nodes.length) {
-    nodes[0].classList.add("hide");
-    nodes[1].classList.add("selected");
+    nodes[0].classList.add("selected");
   }
   loop(nodes, (node, i) => onTabSelect(nodes, node, i));
 });

--- a/docs/state/actions.md
+++ b/docs/state/actions.md
@@ -29,42 +29,155 @@ Key characteristics:
 
 ## Code Examples
 
-### Basic Example: Simple Action Creators
+### Basic Example: Actions across state libraries
 
+The same todo-CRUD actions, authored idiomatically in each of the state libraries the six `chota-*` templates ship. Every flavour here produces the same effect on the store — they differ only in ceremony and in where the "type + payload" envelope is constructed.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Classic Redux
 ```javascript
-// actionTypes.js - Constants prevent typos
-export const ADD_TODO = 'todos/add';
-export const TOGGLE_TODO = 'todos/toggle';
-export const DELETE_TODO = 'todos/delete';
+// templates/chota-react-redux/src/state/todo/todo.actions.js
+import { CREATE_TODO, DELETE_TODO, EDIT_TODO, TOGGLE_TODO, UPDATE_TODO } from "./todo.type";
 
-// actions.js - Action creators
 let nextTodoId = 0;
+export const createTodo = (text) => ({
+  type: CREATE_TODO,
+  payload: { id: nextTodoId++, text },
+});
 
-// Basic action creator
-export function addTodo(text) {
-  return {
-    type: ADD_TODO,
-    payload: {
-      id: nextTodoId++,
-      text,
-      completed: false
-    }
-  };
+export const editTodo = (payload) => ({ type: EDIT_TODO, payload });
+export const updateTodo = (payload) => ({ type: UPDATE_TODO, payload });
+export const deleteTodo = (id) => ({ type: DELETE_TODO, payload: { id } });
+export const toggleTodo = (payload) => ({ type: TOGGLE_TODO, payload });
+```
+
+Redux Toolkit
+```javascript
+// templates/chota-react-rtk/src/state/todo/todo.reducer.js
+// RTK's createSlice auto-generates action creators and types from reducer names.
+import { createSlice } from "@reduxjs/toolkit";
+import intialTodoState from "./todo.initial";
+
+let nextTodoId = 0;
+export const todoSlice = createSlice({
+  name: "todo",
+  initialState: intialTodoState,
+  reducers: {
+    createTodo: (state, action) => {
+      state.todoItems.push({ text: action.payload, completed: false, id: nextTodoId++ });
+    },
+    editTodo: (state, action) => { state.currentTodoItem = action.payload; },
+    toggleTodo: (state, action) => {
+      state.todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, completed: !t.completed } : t);
+    },
+  },
+});
+
+// Action creators are generated for each case reducer:
+export const { createTodo, editTodo, toggleTodo } = todoSlice.actions;
+```
+
+Redux Saga
+```javascript
+// templates/chota-react-saga/src/state/todo/todo.actions.js
+// Plain action creators. Sagas listen for these and dispatch *Success / *Error follow-ups.
+export const createTodo = (payload) => ({ type: CREATE_TODO, payload });
+export const createTodoSuccess = (payload) => ({ type: CREATE_TODO_SUCCESS, payload });
+export const createTodoError = (error) => ({ type: CREATE_TODO_ERROR, error });
+
+export const readTodo = () => ({ type: READ_TODO });
+export const readTodoSuccess = (payload) => ({ type: READ_TODO_SUCCESS, payload });
+export const readTodoError = (error) => ({ type: READ_TODO_ERROR, error });
+
+export const deleteTodo = (payload) => ({ type: DELETE_TODO, payload });
+export const deleteTodoSuccess = () => ({ type: DELETE_TODO_SUCCESS });
+export const deleteTodoError = (previousState, error) => ({
+  type: DELETE_TODO_ERROR,
+  previousState,
+  error,
+});
+```
+
+NgRx
+```typescript
+// templates/chota-angular-ngrx/src/app/state/todo/todo.actions.ts
+import { createAction, props } from '@ngrx/store';
+
+export const createTodo = createAction(
+  '[Todo] CreateTodo',
+  props<{ id: number; text: string }>()
+);
+
+export const editTodo = createAction(
+  '[Todo] EditTodo',
+  props<{ id: number; text: string }>()
+);
+
+export const toggleTodo = createAction(
+  '[Todo] ToggleTodo',
+  props<{ id: number }>()
+);
+
+export const deleteTodo = createAction(
+  '[Todo] DeleteTodo',
+  props<{ id: number }>()
+);
+
+// Request/Success/Fail triples drive NgRx effects:
+export const loadTodosRequest = createAction('[Todo] LoadTodosRequest');
+export const loadTodosSuccess = createAction('[Todo] LoadTodosSuccess');
+export const loadTodosFail = createAction(
+  '[Todo] LoadTodosFail',
+  props<{ error: string }>()
+);
+```
+
+Pinia
+```javascript
+// templates/chota-vue-pinia/src/state/todo/todo.actions.js
+// Pinia "actions" are just methods on the store — they mutate state directly.
+// There's no separate "action object" envelope.
+export function createTodo(text) {
+  this.isLoading = true;
+  this.isActionLoading = true;
+  this.currentTodoItem = { text, completed: false };
 }
 
-export function toggleTodo(id) {
-  return {
-    type: TOGGLE_TODO,
-    payload: id
-  };
+export function createTodoSuccess(payload) {
+  this.isLoading = false;
+  this.todoItems.push({ id: payload.id, text: payload.text, completed: false });
+  this.currentTodoItem = intialTodoState.currentTodoItem;
 }
 
-export function deleteTodo(id) {
-  return {
-    type: DELETE_TODO,
-    payload: id
-  };
-}
+// Wired into the store via defineStore('todo', { actions: { createTodo, ... } }).
+```
+
+Redux Saga (Web Components)
+```javascript
+// templates/chota-wc-saga/src/state/todo/todo.actions.js
+// Same plain-object shape as the React Saga template — the WC template reuses
+// the request/success/error triple because the pattern is framework-agnostic.
+export const createTodo = (text) => ({
+  type: CREATE_TODO,
+  payload: { text, completed: false },
+});
+export const createTodoSuccess = (payload) => ({ type: CREATE_TODO_SUCCESS, payload });
+export const createTodoError = (error) => ({ type: CREATE_TODO_ERROR, error });
+
+export const toggleTodo = (payload) => ({ type: TOGGLE_TODO, payload });
+export const toggleTodoSuccess = () => ({ type: TOGGLE_TODO_SUCCESS });
+```
+
+{::nomarkdown}</div>{:/}
+
+What to notice:
+
+- **Redux / Saga / WC-Saga** all ship the same primitive: plain `{ type, payload }` objects and little creator functions. Saga variants add explicit `*Success` / `*Error` follow-ups because the middleware expects them.
+- **RTK** hides both the type constants and the plain-object creators — you only write the reducer case names, and it synthesises everything.
+- **NgRx** uses `createAction` + `props<...>()` to give you a typed creator that still produces a conventional `{ type, ...payload }` action object.
+- **Pinia** is the odd one out: it has no action *objects* at all. Actions are methods on the store that mutate `this` — the devtools still show them as discrete events, but you don't author a creator.
 
 // Usage in components
 import { useDispatch } from 'react-redux';

--- a/docs/ui/atom.md
+++ b/docs/ui/atom.md
@@ -28,54 +28,136 @@ In the Universal Frontend Architecture, atoms bridge the gap between design and 
 
 ## Code Examples
 
-### Basic Example: Simple Button Atom
+### Basic Example: Button Atom across frameworks
 
-A fundamental button atom demonstrating single-purpose design:
+Here's the same single-purpose Button atom pulled directly from each `chota-*` template. The shape is intentionally identical across all four: one prop-driven button that swaps to a `Loader` while `isLoading` is true, and emits a click otherwise. Compare how each framework expresses the same pattern.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// Button.js
+// templates/chota-react-redux/src/ui/atoms/Button/Button.component.jsx
+import Loader from "../Loader/Loader.component";
+import './Button.style.css';
 
-import React from "react";
-
-const Button = ({ onClick, label }) => {
-  return <button onClick={onClick}>{label}</button>;
-};
-
-export default Button;
+export default function Button(props) {
+  const transformedProps = { ...props };
+  delete transformedProps.isLoading;
+  if (props.isLoading) {
+    return (
+      <button {...transformedProps} className={`${props.className} loading-button`}>
+        <Loader width="2px" size="1.2rem" color="#fff" />
+      </button>
+    );
+  }
+  return <button {...transformedProps}>{props.children}</button>;
+}
 ```
 
-In this example, the Button component is a basic building block (atom) that takes two props:
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Button/Button.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import LoaderComponent from '../Loader/Loader.component';
 
-- `onClick`: a function to be called when the button is clicked.
-- `label`: the text content of the button.
+@Component({
+  selector: 'app-button',
+  standalone: true,
+  imports: [LoaderComponent],
+  templateUrl: './Button.component.html',
+  styleUrls: ['./Button.style.css'],
+})
+export default class ButtonComponent {
+  @Input() isLoading = false;
+  @Input() classes?: string;
+  @Input() type = '';
 
-This simple Button component can be reused throughout the application wherever a button is needed. When combining multiple atoms like this, we can start building more complex components (molecules, organisms, etc.) by composing them together.
+  get computedClasses() {
+    return this.isLoading ? `${this.classes} loading-button` : this.classes;
+  }
 
-Here's an example of how we might use this Button component in a parent component:
-
-```jsx
-// App.js
-
-import React from "react";
-import Button from "./Button";
-
-const App = () => {
-  const handleClick = () => {
-    alert("Button clicked!");
-  };
-
-  return (
-    <div>
-      <h1>My App</h1>
-      <Button onClick={handleClick} label="Click me" />
-    </div>
-  );
-};
-
-export default App;
+  @Output() onClick = new EventEmitter<Event>();
+}
 ```
 
-In this example, the `App` component uses the `Button` atom by passing in an `onClick` function and a `label`. This follows the Atomic Design principles of building up more complex components by combining simpler ones.
+```html
+<!-- Button.component.html -->
+@if (isLoading) {
+  <button [class]="computedClasses" [disabled]="isLoading">
+    <app-loader width="2px" size="1.2rem" color="#fff"></app-loader>
+  </button>
+} @else {
+  <button [type]="type || 'button'" (click)="onClick.emit($event)" [class]="computedClasses">
+    <ng-content></ng-content>
+  </button>
+}
+```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Button/Button.component.vue -->
+<template>
+  <button v-if="isLoading" :disabled="disabled" @click="$emit('onClick')" :class="getButtonClass()">
+    <Loader width="2px" size="1.2rem" color="#fff" />
+  </button>
+  <button v-else :disabled="disabled" :type="type" @click="$emit('onClick')" :class="getButtonClass()">
+    <slot />
+  </button>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+import Loader from '../Loader/Loader.component.vue';
+
+export default defineComponent({
+  components: { Loader },
+  props: ['isLoading', 'class', 'disabled', 'onClick', 'label', 'type'],
+  methods: {
+    getButtonClass() {
+      return `${this.class} loading-button`;
+    },
+  },
+})
+</script>
+
+<style scoped src="./Button.style.css"></style>
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Button/Button.component.js
+import { html } from "lit";
+import style from './Button.style';
+import "../Loader/app-loader";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+import emit from "../../../utils/events/emit";
+
+export default function Button(props) {
+  useComputedStyles(this, [style]);
+  if (props.isLoading) {
+    return html`
+      <button type="button" class=${`${props.classes} loading-button`}>
+        <app-loader .width=${'2px'} .size=${'1.2rem'} .color=${'#fff'}>Loading...</app-loader>
+      </button>
+    `;
+  }
+  return html`
+    <button type="button"
+      class="${props.classes}"
+      @click="${() => emit(this, "onClick", props)}">
+      <slot></slot>
+    </button>
+  `;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+A few things worth comparing across the tabs:
+
+- **Children projection.** React uses `{props.children}`, Angular uses `<ng-content>`, Vue and Web Components both use `<slot>` — four spellings of the same idea.
+- **Event shape.** React passes `onClick` through as a plain prop. Angular exposes an `@Output() EventEmitter`. Vue emits `'onClick'` via `$emit`. The Lit-based WC uses a tiny `emit(this, "onClick", props)` helper wrapping `CustomEvent`.
+- **Styling.** Every template co-locates `Button.style.css` next to the component; Angular and Vue scope it, React imports it side-effect style, WC injects via `useComputedStyles`.
 
 ### Advanced Example: Icon Atom with Dynamic SVG Loading
 


### PR DESCRIPTION
## Summary

The `.code-tabs` mechanism (CSS + JS in `docs/assets/`) already exists but was only used in one stale blog post. Terminology docs showed React-only code snippets even though the repo ships six templates across React/Redux, RTK, Redux Saga, Angular/NgRx, Vue/Pinia and Lit/WC-Saga. Readers never saw how the same concept reads in their stack.

### Fixes

- **Tab JS.** Previously hid the first `<p>` and selected the second — a legacy pattern that required a spacer tab. Simplified to select the first real tab so the natural markup works.
- **`docs/ui/atom.md`** — replaces the React-only Button example in *Basic Example* with a tabbed view of `Button.component.*` pulled verbatim from each UI template: **React · Angular · Vue · Web Components (Lit)**. Adds a short callout comparing children projection (`children` / `ng-content` / `slot` / `slot`), event dispatch (prop / `@Output` / `$emit` / `emit` helper), and style co-location across the four frameworks.
- **`docs/state/actions.md`** — replaces the React-only *Simple Action Creators* example with tabs covering **Classic Redux · Redux Toolkit · Redux Saga · NgRx · Pinia · WC-Saga**. Adds a callout on how each library expresses the action envelope (or skips it entirely in Pinia's case).

### Pattern for follow-ups

The same approach can be rolled out incrementally to `molecule.md`, `organism.md`, `reducer.md`, `store.md`, `selectors.md`, etc. — each time, pulling the real component/slice from the six templates and letting the tabs make the side-by-side comparison.

## Test plan
- [ ] Verify tabs render with the first tab (e.g. "React") pre-selected
- [ ] Click through tabs on the deployed Pages site: clicking switches both the underline and the code block below
- [ ] Copy-button still works inside each tab's code block

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG)_