### PR TITLE
Docs: cross-framework tabs for attributes and theme

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -99,8 +99,7 @@ tabsNodes = document.querySelectorAll(".code-tabs");
 loop(tabsNodes, (tabsNode) => {
   nodes = tabsNode.querySelectorAll("p");
   if (nodes.length) {
-    nodes[0].classList.add("hide");
-    nodes[1].classList.add("selected");
+    nodes[0].classList.add("selected");
   }
   loop(nodes, (node, i) => onTabSelect(nodes, node, i));
 });

--- a/docs/server/container.md
+++ b/docs/server/container.md
@@ -50,138 +50,222 @@ References
 - [1] https://medium.com/@learnreact/container-components-c0e67432e005
 ## Code Examples
 
-### Basic Example: TodoList Container Pattern
+### Basic Example: TodoListContainer across frameworks
 
-```javascript
-// ===== PRESENTATIONAL COMPONENT =====
-// TodoList.js - Pure presentational component
+The same container pulled from each `chota-*` template: it subscribes to the store, derives a filtered view of todos via selectors, and fans `{ todoData, events }` into the presentational `TodoList` organism. Identical interface out the top, framework-native wiring down the side.
 
-import React from 'react';
-import PropTypes from 'prop-types';
+{::nomarkdown}<div class="code-tabs">{:/}
 
-function TodoList({ todos, onToggle, onDelete, isLoading, error }) {
-  if (isLoading) {
-    return <div className="loading">Loading todos...</div>;
-  }
-  
-  if (error) {
-    return <div className="error">Error: {error}</div>;
-  }
-  
-  if (todos.length === 0) {
-    return <div className="empty">No todos yet. Add one!</div>;
-  }
-  
-  return (
-    <ul className="todo-list">
-      {todos.map(todo => (
-        <li key={todo.id} className={todo.completed ? 'completed' : ''}>
-          <input
-            type="checkbox"
-            checked={todo.completed}
-            onChange={() => onToggle(todo.id)}
-            aria-label={`Mark "${todo.text}" as ${todo.completed ? 'incomplete' : 'complete'}`}
-          />
-          <span>{todo.text}</span>
-          <button 
-            onClick={() => onDelete(todo.id)}
-            aria-label={`Delete "${todo.text}"`}>
-            Delete
-          </button>
-        </li>
-      ))}
-    </ul>
+React + Redux
+```jsx
+// templates/chota-react-redux/src/containers/TodoListContainer.jsx
+// (The chota-react-rtk variant is identical — RTK's slice-generated
+// actions plug into useDispatch the same way.)
+import TodoList from "../ui/organisms/TodoList/TodoList.component";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  createTodo, deleteTodo, editTodo, toggleTodo, updateTodo,
+} from "../state/todo/todo.actions";
+import { getSelectedFilter } from "../state/filters/filters.selectors";
+import { getVisibleTodos } from "../state/todo/todo.selectors";
+
+export default function TodoListContainer() {
+  const dispatch = useDispatch();
+  const selectedFilter = useSelector(getSelectedFilter);
+  const todoData = useSelector((state) =>
+    getVisibleTodos(state.todo, selectedFilter.id)
   );
+
+  const events = {
+    onTodoCreate: (payload) => dispatch(createTodo(payload)),
+    onTodoEdit: (payload) => dispatch(editTodo(payload)),
+    onTodoUpdate: (text) =>
+      dispatch(updateTodo({ id: todoData.currentTodoItem.id, text })),
+    onTodoToggleUpdate: (id) => dispatch(toggleTodo(id)),
+    onTodoDelete: (payload) => dispatch(deleteTodo(payload)),
+  };
+
+  return <TodoList todoData={todoData} events={events} />;
 }
-
-// PropTypes document data expectations
-TodoList.propTypes = {
-  todos: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      text: PropTypes.string.isRequired,
-      completed: PropTypes.bool.isRequired
-    })
-  ).isRequired,
-  onToggle: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
-  isLoading: PropTypes.bool,
-  error: PropTypes.string
-};
-
-export default TodoList;
-
-
-// ===== CONTAINER COMPONENT (Class Component) =====
-// TodoListContainer.js - Handles data fetching and state
-
-import React, { Component } from 'react';
-import TodoList from './TodoList';
-import { fetchTodos, updateTodo, deleteTodo } from '../api/todos';
-
-class TodoListContainer extends Component {
-  state = {
-    todos: [],
-    isLoading: true,
-    error: null
-  };
-  
-  componentDidMount() {
-    this.loadTodos();
-  }
-  
-  loadTodos = async () => {
-    try {
-      this.setState({ isLoading: true, error: null });
-      const todos = await fetchTodos();
-      this.setState({ todos, isLoading: false });
-    } catch (error) {
-      this.setState({ error: error.message, isLoading: false });
-    }
-  };
-  
-  handleToggle = async (id) => {
-    const todo = this.state.todos.find(t => t.id === id);
-    if (!todo) return;
-    
-    try {
-      const updated = await updateTodo(id, { completed: !todo.completed });
-      this.setState(prevState => ({
-        todos: prevState.todos.map(t => t.id === id ? updated : t)
-      }));
-    } catch (error) {
-      console.error('Failed to update todo:', error);
-    }
-  };
-  
-  handleDelete = async (id) => {
-    try {
-      await deleteTodo(id);
-      this.setState(prevState => ({
-        todos: prevState.todos.filter(t => t.id !== id)
-      }));
-    } catch (error) {
-      console.error('Failed to delete todo:', error);
-    }
-  };
-  
-  render() {
-    const { todos, isLoading, error } = this.state;
-    
-    return (
-      <TodoList
-        todos={todos}
-        onToggle={this.handleToggle}
-        onDelete={this.handleDelete}
-        isLoading={isLoading}
-        error={error}
-      />
-    );
-  }
-}
-
-export default TodoListContainer;
 ```
+
+React + Saga
+```jsx
+// templates/chota-react-saga/src/containers/TodoListContainer.jsx
+// Same as the Redux container, plus a useEffect that kicks off the
+// initial READ_TODO dispatch — sagas pick that up and fetch from the API.
+// The WC-Saga TodoListContainer does the same thing with a LitElement
+// connected to the store via pwa-helpers.
+import { useEffect } from "react";
+import TodoList from "../ui/organisms/TodoList/TodoList.component";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  createTodo, deleteTodo, editTodo, readTodo, toggleTodo, updateTodo,
+} from "../state/todo/todo.actions";
+import { getSelectedFilter } from "../state/filters/filters.selectors";
+import { getVisibleTodos } from "../state/todo/todo.selectors";
+
+export default function TodoListContainer() {
+  const dispatch = useDispatch();
+  const selectedFilter = useSelector(getSelectedFilter);
+  const todoData = useSelector((state) =>
+    getVisibleTodos(state.todo, selectedFilter.id)
+  );
+
+  useEffect(() => {
+    dispatch(readTodo());
+  }, [dispatch]);
+
+  const events = {
+    onTodoCreate: (payload) => dispatch(createTodo(payload)),
+    onTodoEdit: (payload) => dispatch(editTodo(payload)),
+    onTodoUpdate: (text) =>
+      dispatch(updateTodo({ id: todoData.currentTodoItem.id, text })),
+    onTodoToggleUpdate: (id) => dispatch(toggleTodo(id)),
+    onTodoDelete: (payload) => dispatch(deleteTodo(payload)),
+  };
+
+  return <TodoList todoData={todoData} events={events} />;
+}
+```
+
+Angular + NgRx
+```typescript
+// templates/chota-angular-ngrx/src/containers/TodoListContainer.ts
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { take } from 'rxjs/operators';
+import { AppState } from '../app/state/index';
+import { getVisibleTodos, getTodoState } from '../app/state/todo/todo.selectors';
+import { Todo } from '../app/state/todo/todo.model';
+import {
+  addTodoRequest, editTodo, updateTodoRequest, toggleTodo, deleteTodoRequest,
+} from '../app/state/todo/todo.actions';
+import TodoListComponent from '../ui/organisms/TodoList/TodoList.component';
+
+@Component({
+  selector: 'app-todo-list-container',
+  standalone: true,
+  imports: [TodoListComponent, AsyncPipe],
+  template: `
+    @if (todoData$ | async; as todoData) {
+      <app-todo-list [todoData]="todoData" [events]="events"></app-todo-list>
+    }
+  `,
+})
+export default class TodoListContainerComponent {
+  todoData$ = this.store.select(getVisibleTodos);
+
+  events = {
+    onTodoCreate: (text: string) => this.store.dispatch(addTodoRequest({ text })),
+    onTodoEdit: (todo: Todo) =>
+      this.store.dispatch(editTodo({ id: todo.id, text: todo.text })),
+    onTodoUpdate: (text: string) => {
+      this.store.select(getTodoState).pipe(take(1)).subscribe((state) => {
+        const { id } = state.currentTodoItem;
+        if (id !== null) this.store.dispatch(updateTodoRequest({ id, text }));
+      });
+    },
+    onTodoToggleUpdate: (todo: Todo) =>
+      this.store.dispatch(toggleTodo({ id: todo.id })),
+    onTodoDelete: (id: number) =>
+      this.store.dispatch(deleteTodoRequest({ id })),
+  };
+
+  constructor(private store: Store<AppState>) {}
+}
+```
+
+Vue + Pinia
+```vue
+<!-- templates/chota-vue-pinia/src/containers/TodoListContainer.vue -->
+<template>
+  <TodoList :todoData="todoData.visibleTodos" :events="events" />
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+import { useFiltersStore } from '../state/filters';
+import { useTodoStore } from '../state/todo';
+import TodoList from '../ui/organisms/TodoList/TodoList.component.vue';
+
+export default defineComponent({
+  components: { TodoList },
+  setup() {
+    const filtersData = useFiltersStore();
+    const todoData = useTodoStore();
+    todoData.getTodos();
+
+    const events = {
+      onTodoCreate: (payload) => todoData.addTodos(payload),
+      onTodoEdit: (payload) => todoData.editTodo(payload),
+      onTodoUpdate: (text) =>
+        todoData.updateTodos({ id: todoData.currentTodoItem.id, text }),
+      onTodoToggleUpdate: (todo) => todoData.updateToggleTodos(todo),
+      onTodoDelete: (payload) => todoData.deleteTodos(payload),
+    };
+
+    return { filtersData, todoData, events };
+  },
+});
+</script>
+```
+
+Web Components + Saga
+```js
+// templates/chota-wc-saga/src/containers/TodoListContainer.js
+// LitElement + pwa-helpers `connect()` subscribes a custom element to the
+// store. `stateChanged` is called on every dispatched action. Same events
+// bag as the React-Saga container; same readTodo() kick-off on construct.
+import { LitElement, html } from 'lit-element';
+import { connect } from 'pwa-helpers';
+import store, { useDispatch } from '../state';
+import {
+  createTodo, deleteTodo, editTodo, readTodo, toggleTodo, updateTodo,
+} from "../state/todo/todo.actions";
+import { getSelectedFilter } from "../state/filters/filters.selectors";
+import { getVisibleTodos } from "../state/todo/todo.selectors";
+import "../ui/organisms/TodoList/app-todo-list";
+
+export default class TodoListContainer extends connect(store)(LitElement) {
+  static get properties() {
+    return {
+      todoData: { type: Object },
+      selectedFilter: { type: Object },
+      events: { type: Object },
+    };
+  }
+  constructor() {
+    super();
+    const dispatch = useDispatch();
+    this.events = {
+      onTodoCreate: (e) => dispatch(createTodo(e.detail)),
+      onTodoEdit: (e) => dispatch(editTodo(e.detail)),
+      onTodoUpdate: (e) =>
+        dispatch(updateTodo({ id: this.todoData.currentTodoItem.id, text: e.detail })),
+      onTodoToggleUpdate: (e) => dispatch(toggleTodo(e.detail)),
+      onTodoDelete: (e) => dispatch(deleteTodo(e.detail)),
+    };
+    dispatch(readTodo());
+  }
+  stateChanged(state) {
+    this.selectedFilter = getSelectedFilter(state);
+    this.todoData = getVisibleTodos(state.todo, this.selectedFilter.id);
+  }
+  render() {
+    return html`<app-todo-list .todoData=${this.todoData} .events=${this.events}></app-todo-list>`;
+  }
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+The outward shape is always the same: a container component that selects from the store, builds an `events` callback bag, and renders the presentational organism with `{ todoData, events }`. What changes:
+
+- **Subscription mechanism.** `useSelector` (React) / `store.select(...).pipe(take(1))` / pwa-helpers `connect()` with `stateChanged` / Pinia's direct store access in `setup()`.
+- **Dispatch shape.** `dispatch(action)` in the Redux family; `store.dispatch(...)` in NgRx; store method calls (`todoData.addTodos(...)`) in Pinia; the same `dispatch(action)` in WC-Saga with the wrinkle that child events arrive as `CustomEvent` so handlers read `e.detail`.
+- **Initial fetch.** Saga templates dispatch `readTodo()` on mount (React's `useEffect`, Lit's `constructor`); Pinia calls `todoData.getTodos()` directly in `setup`.
 
 ### Practical Example: Modern React Hooks Approach
 

--- a/docs/state/actions.md
+++ b/docs/state/actions.md
@@ -29,42 +29,155 @@ Key characteristics:
 
 ## Code Examples
 
-### Basic Example: Simple Action Creators
+### Basic Example: Actions across state libraries
 
+The same todo-CRUD actions, authored idiomatically in each of the state libraries the six `chota-*` templates ship. Every flavour here produces the same effect on the store — they differ only in ceremony and in where the "type + payload" envelope is constructed.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Classic Redux
 ```javascript
-// actionTypes.js - Constants prevent typos
-export const ADD_TODO = 'todos/add';
-export const TOGGLE_TODO = 'todos/toggle';
-export const DELETE_TODO = 'todos/delete';
+// templates/chota-react-redux/src/state/todo/todo.actions.js
+import { CREATE_TODO, DELETE_TODO, EDIT_TODO, TOGGLE_TODO, UPDATE_TODO } from "./todo.type";
 
-// actions.js - Action creators
 let nextTodoId = 0;
+export const createTodo = (text) => ({
+  type: CREATE_TODO,
+  payload: { id: nextTodoId++, text },
+});
 
-// Basic action creator
-export function addTodo(text) {
-  return {
-    type: ADD_TODO,
-    payload: {
-      id: nextTodoId++,
-      text,
-      completed: false
-    }
-  };
+export const editTodo = (payload) => ({ type: EDIT_TODO, payload });
+export const updateTodo = (payload) => ({ type: UPDATE_TODO, payload });
+export const deleteTodo = (id) => ({ type: DELETE_TODO, payload: { id } });
+export const toggleTodo = (payload) => ({ type: TOGGLE_TODO, payload });
+```
+
+Redux Toolkit
+```javascript
+// templates/chota-react-rtk/src/state/todo/todo.reducer.js
+// RTK's createSlice auto-generates action creators and types from reducer names.
+import { createSlice } from "@reduxjs/toolkit";
+import intialTodoState from "./todo.initial";
+
+let nextTodoId = 0;
+export const todoSlice = createSlice({
+  name: "todo",
+  initialState: intialTodoState,
+  reducers: {
+    createTodo: (state, action) => {
+      state.todoItems.push({ text: action.payload, completed: false, id: nextTodoId++ });
+    },
+    editTodo: (state, action) => { state.currentTodoItem = action.payload; },
+    toggleTodo: (state, action) => {
+      state.todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, completed: !t.completed } : t);
+    },
+  },
+});
+
+// Action creators are generated for each case reducer:
+export const { createTodo, editTodo, toggleTodo } = todoSlice.actions;
+```
+
+Redux Saga
+```javascript
+// templates/chota-react-saga/src/state/todo/todo.actions.js
+// Plain action creators. Sagas listen for these and dispatch *Success / *Error follow-ups.
+export const createTodo = (payload) => ({ type: CREATE_TODO, payload });
+export const createTodoSuccess = (payload) => ({ type: CREATE_TODO_SUCCESS, payload });
+export const createTodoError = (error) => ({ type: CREATE_TODO_ERROR, error });
+
+export const readTodo = () => ({ type: READ_TODO });
+export const readTodoSuccess = (payload) => ({ type: READ_TODO_SUCCESS, payload });
+export const readTodoError = (error) => ({ type: READ_TODO_ERROR, error });
+
+export const deleteTodo = (payload) => ({ type: DELETE_TODO, payload });
+export const deleteTodoSuccess = () => ({ type: DELETE_TODO_SUCCESS });
+export const deleteTodoError = (previousState, error) => ({
+  type: DELETE_TODO_ERROR,
+  previousState,
+  error,
+});
+```
+
+NgRx
+```typescript
+// templates/chota-angular-ngrx/src/app/state/todo/todo.actions.ts
+import { createAction, props } from '@ngrx/store';
+
+export const createTodo = createAction(
+  '[Todo] CreateTodo',
+  props<{ id: number; text: string }>()
+);
+
+export const editTodo = createAction(
+  '[Todo] EditTodo',
+  props<{ id: number; text: string }>()
+);
+
+export const toggleTodo = createAction(
+  '[Todo] ToggleTodo',
+  props<{ id: number }>()
+);
+
+export const deleteTodo = createAction(
+  '[Todo] DeleteTodo',
+  props<{ id: number }>()
+);
+
+// Request/Success/Fail triples drive NgRx effects:
+export const loadTodosRequest = createAction('[Todo] LoadTodosRequest');
+export const loadTodosSuccess = createAction('[Todo] LoadTodosSuccess');
+export const loadTodosFail = createAction(
+  '[Todo] LoadTodosFail',
+  props<{ error: string }>()
+);
+```
+
+Pinia
+```javascript
+// templates/chota-vue-pinia/src/state/todo/todo.actions.js
+// Pinia "actions" are just methods on the store — they mutate state directly.
+// There's no separate "action object" envelope.
+export function createTodo(text) {
+  this.isLoading = true;
+  this.isActionLoading = true;
+  this.currentTodoItem = { text, completed: false };
 }
 
-export function toggleTodo(id) {
-  return {
-    type: TOGGLE_TODO,
-    payload: id
-  };
+export function createTodoSuccess(payload) {
+  this.isLoading = false;
+  this.todoItems.push({ id: payload.id, text: payload.text, completed: false });
+  this.currentTodoItem = intialTodoState.currentTodoItem;
 }
 
-export function deleteTodo(id) {
-  return {
-    type: DELETE_TODO,
-    payload: id
-  };
-}
+// Wired into the store via defineStore('todo', { actions: { createTodo, ... } }).
+```
+
+Redux Saga (Web Components)
+```javascript
+// templates/chota-wc-saga/src/state/todo/todo.actions.js
+// Same plain-object shape as the React Saga template — the WC template reuses
+// the request/success/error triple because the pattern is framework-agnostic.
+export const createTodo = (text) => ({
+  type: CREATE_TODO,
+  payload: { text, completed: false },
+});
+export const createTodoSuccess = (payload) => ({ type: CREATE_TODO_SUCCESS, payload });
+export const createTodoError = (error) => ({ type: CREATE_TODO_ERROR, error });
+
+export const toggleTodo = (payload) => ({ type: TOGGLE_TODO, payload });
+export const toggleTodoSuccess = () => ({ type: TOGGLE_TODO_SUCCESS });
+```
+
+{::nomarkdown}</div>{:/}
+
+What to notice:
+
+- **Redux / Saga / WC-Saga** all ship the same primitive: plain `{ type, payload }` objects and little creator functions. Saga variants add explicit `*Success` / `*Error` follow-ups because the middleware expects them.
+- **RTK** hides both the type constants and the plain-object creators — you only write the reducer case names, and it synthesises everything.
+- **NgRx** uses `createAction` + `props<...>()` to give you a typed creator that still produces a conventional `{ type, ...payload }` action object.
+- **Pinia** is the odd one out: it has no action *objects* at all. Actions are methods on the store that mutate `this` — the devtools still show them as discrete events, but you don't author a creator.
 
 // Usage in components
 import { useDispatch } from 'react-redux';

--- a/docs/state/middleware.md
+++ b/docs/state/middleware.md
@@ -55,40 +55,132 @@ Middleware is particularly useful for handling various aspects of state manageme
 
 ## Code Examples
 
-### Basic Example: Simple Logger Middleware
+### Basic Example: Async orchestration across libraries
 
+The clearest place to see middleware in action is async work — fetch data, dispatch *Success* / *Error* outcomes. Each `chota-*` template solves the same "create a todo on the server, then update the store" problem with its native middleware story. RTK ships built-in middleware (immutable check, serializable check, thunks) via `configureStore` so you rarely write custom middleware in plain RTK; saga / NgRx Effects / Pinia operations do the heavy lifting in their respective templates.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Redux Saga
 ```javascript
-// loggerMiddleware.js - Basic middleware structure
-const loggerMiddleware = (store) => (next) => (action) => {
-  console.group(action.type);
-  console.log('Dispatching:', action);
-  console.log('Previous State:', store.getState());
-  
-  const result = next(action);  // Pass to next middleware or reducer
-  
-  console.log('Next State:', store.getState());
-  console.groupEnd();
-  
-  return result;  // Return result for dispatch() caller
-};
+// templates/chota-react-saga/src/state/todo/todo.operations.js
+// Sagas are the middleware: takeLatest / call / put orchestrate the side
+// effect. Failure dispatches the *_ERROR action; the reducer reacts.
+import { put, takeLatest, call } from "redux-saga/effects";
+import { CREATE_TODO } from "./todo.type";
+import { createTodoError, createTodoSuccess } from "./todo.actions";
+import fetchApi from "../../utils/api";
 
-// Apply middleware to store
-import { createStore, applyMiddleware } from 'redux';
-import rootReducer from './reducers';
+export function addTodoApi(payload) {
+  return fetchApi("/todos", { method: "POST", body: payload });
+}
 
-const store = createStore(
-  rootReducer,
-  applyMiddleware(loggerMiddleware)
-);
+export function* addTodos(action) {
+  try {
+    const payload = { ...action.payload, id: window.crypto.randomUUID() };
+    yield call(addTodoApi, payload);
+    yield put(createTodoSuccess(payload));
+  } catch (error) {
+    yield put(createTodoError(error.toString()));
+  }
+}
 
-// Usage
-store.dispatch({ type: 'todos/add', payload: 'Buy milk' });
-// Console output:
-// todos/add
-//   Dispatching: { type: 'todos/add', payload: 'Buy milk' }
-//   Previous State: { todos: [] }
-//   Next State: { todos: [{ text: 'Buy milk' }] }
+export function* watchTodos() {
+  yield takeLatest(CREATE_TODO, addTodos);
+  // ...DELETE_TODO, UPDATE_TODO, READ_TODO, TOGGLE_TODO
+}
 ```
+
+NgRx Effects
+```typescript
+// templates/chota-angular-ngrx/src/app/state/todo/todo.effects.ts
+// NgRx Effects are RxJS pipes that listen to action streams and dispatch
+// follow-up actions. createEffect + ofType is the saga-equivalent.
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { switchMap, mergeMap, catchError } from 'rxjs/operators';
+import { TodoService } from './todo.service';
+import * as TodoActions from './todo.actions';
+
+@Injectable()
+export class TodoEffects {
+  addTodoRequest$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TodoActions.addTodoRequest),
+      switchMap(({ text }) =>
+        this.todoService.createTodo(text).pipe(
+          mergeMap((todo) => [
+            TodoActions.createTodo({ id: todo.id, text: todo.text }),
+            TodoActions.addTodoSuccess(),
+          ]),
+          catchError((error) =>
+            of(TodoActions.addTodoFail({
+              error: error.message || 'Failed to add todo',
+            }))
+          )
+        )
+      )
+    )
+  );
+
+  constructor(private actions$: Actions, private todoService: TodoService) {}
+}
+```
+
+Pinia operations
+```javascript
+// templates/chota-vue-pinia/src/state/todo/todo.operations.js
+// Pinia "actions" can be async, so the operation is just an `async function`
+// bound to the store. There's no middleware layer at all — the store method
+// awaits the API and calls request/success/error helpers (which mutate
+// `this`). Same control flow as a saga, expressed as straight async/await.
+import { createTodo, createTodoSuccess, createTodoError } from "./todo.actions";
+import fetchApi from "../../utils/api";
+
+export function addTodoApi(payload) {
+  return fetchApi("/todos", { method: "POST", body: payload });
+}
+
+export async function addTodos(text) {
+  try {
+    createTodo.bind(this)(text);
+    const payload = { text, id: window.crypto.randomUUID() };
+    await addTodoApi(payload);
+    createTodoSuccess.bind(this)(payload);
+  } catch (error) {
+    createTodoError.bind(this)(error.toString());
+  }
+}
+```
+
+Redux Toolkit (built-in middleware)
+```javascript
+// templates/chota-react-rtk/src/state/index.js
+// configureStore wires up immutable-check, serializable-check, and the
+// thunk middleware automatically. You only write custom middleware when
+// you have a cross-cutting concern beyond async — logging, analytics,
+// crash reporting — and pass it via the `middleware` callback.
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "./rootReducer";
+
+const store = configureStore({
+  reducer: rootReducer,
+  // Defaults already include thunk + checks; extend like:
+  // middleware: (getDefault) => getDefault().concat(myLogger),
+});
+
+export default store;
+```
+
+{::nomarkdown}</div>{:/}
+
+The conceptual job is identical in every tab: intercept an action, run a side effect, dispatch follow-up actions to update the store. The libraries differ in *where* you write that interception:
+
+- **Saga**: a generator function plus a `takeLatest(action, saga)` watcher, run via `sagaMiddleware`.
+- **NgRx Effects**: an injectable class whose properties are RxJS observables, registered via `provideEffects`.
+- **Pinia**: skip the middleware layer entirely — just write an `async` store method. Reactivity propagates the mutations.
+- **RTK**: most apps don't write middleware at all because `configureStore` ships sensible defaults plus thunks; you only reach for custom middleware for genuinely cross-cutting concerns.
 
 ### Practical Example: Async Middleware (Thunk Pattern)
 

--- a/docs/state/reducer.md
+++ b/docs/state/reducer.md
@@ -29,50 +29,161 @@ Key characteristics of reducers:
 
 ## Code Examples
 
-### Basic Example: Simple Counter Reducer
+### Basic Example: Todo reducer across state libraries
 
+The same "todo slice" implemented four different ways, pulled from the actual templates. Notice that Classic Redux and Redux Saga use the same switch/case reducer (Saga adds request/success/error branches); RTK compresses the same effect into `createSlice` with Immer-backed mutating-looking code; NgRx uses `createReducer(on(...))`. Pinia doesn't have a reducer at all — its "actions" mutate the store state directly — so it isn't listed here.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Classic Redux
 ```javascript
-// counterReducer.js - Basic pure function reducer
-const initialState = {
-  count: 0,
-  history: []
-};
+// templates/chota-react-redux/src/state/todo/todo.reducer.js
+import intialTodoState from "./todo.initial";
+import { CREATE_TODO, DELETE_TODO, EDIT_TODO, TOGGLE_TODO, UPDATE_TODO } from "./todo.type";
 
-function counterReducer(state = initialState, action) {
+const todo = (state = intialTodoState, action) => {
+  let todoItems = [];
   switch (action.type) {
-    case 'INCREMENT':
+    case CREATE_TODO:
       return {
         ...state,
-        count: state.count + 1,
-        history: [...state.history, 'increment']
+        todoItems: [
+          ...state.todoItems,
+          { id: action.payload.id, text: action.payload.text, completed: false },
+        ],
       };
-    
-    case 'DECREMENT':
-      return {
-        ...state,
-        count: state.count - 1,
-        history: [...state.history, 'decrement']
-      };
-    
-    case 'RESET':
-      return initialState;  // Return fresh initial state
-    
+    case EDIT_TODO:
+      return { ...state, currentTodoItem: action.payload };
+    case UPDATE_TODO:
+      todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, text: action.payload.text } : t);
+      return { ...state, todoItems, currentTodoItem: intialTodoState.currentTodoItem };
+    case TOGGLE_TODO:
+      todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, completed: !t.completed } : t);
+      return { ...state, todoItems };
+    case DELETE_TODO:
+      todoItems = state.todoItems.filter((t) => t.id !== action.payload.id);
+      return { ...state, todoItems };
     default:
-      return state;  // CRITICAL: always return state for unknown actions
+      return state;
   }
-}
-
-// Usage with Redux
-import { createStore } from 'redux';
-const store = createStore(counterReducer);
-
-store.dispatch({ type: 'INCREMENT' });
-console.log(store.getState());  // { count: 1, history: ['increment'] }
-
-store.dispatch({ type: 'INCREMENT' });
-store.dispatch({ type: 'DECREMENT' });
-console.log(store.getState());  // { count: 1, history: ['increment', 'increment', 'decrement'] }
+};
+export default todo;
 ```
+
+Redux Toolkit
+```javascript
+// templates/chota-react-rtk/src/state/todo/todo.reducer.js
+// createSlice + Immer lets you write mutating-looking code that still
+// produces an immutable update under the hood. The slice also auto-emits
+// action creators and types.
+import { createSlice } from "@reduxjs/toolkit";
+import intialTodoState from "./todo.initial";
+
+let nextTodoId = 0;
+export const todoSlice = createSlice({
+  name: "todo",
+  initialState: intialTodoState,
+  reducers: {
+    createTodo: (state, action) => {
+      state.todoItems.push({ text: action.payload, completed: false, id: nextTodoId++ });
+    },
+    editTodo: (state, action) => { state.currentTodoItem = action.payload; },
+    updateTodo: (state, action) => {
+      state.todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, text: action.payload.text } : t);
+      state.currentTodoItem = intialTodoState.currentTodoItem;
+    },
+    toggleTodo: (state, action) => {
+      state.todoItems = state.todoItems.map((t) =>
+        t.id === action.payload.id ? { ...t, completed: !t.completed } : t);
+    },
+  },
+});
+export const { createTodo, editTodo, updateTodo, toggleTodo } = todoSlice.actions;
+export default todoSlice.reducer;
+```
+
+Redux Saga
+```javascript
+// templates/chota-react-saga/src/state/todo/todo.reducer.js
+// Same switch/case shape as Classic Redux, plus *_SUCCESS / *_ERROR branches
+// because sagas dispatch those after completing async work. The React-Saga
+// and WC-Saga templates share this exact reducer — the saga pattern is
+// framework-agnostic.
+import intialTodoState from "./todo.initial";
+import {
+  CREATE_TODO, CREATE_TODO_SUCCESS, CREATE_TODO_ERROR,
+  READ_TODO, READ_TODO_SUCCESS, READ_TODO_ERROR,
+  TOGGLE_TODO, TOGGLE_TODO_SUCCESS, TOGGLE_TODO_ERROR,
+  /* ...DELETE_*, UPDATE_*, EDIT_TODO... */
+} from "./todo.type";
+
+const todo = (state = intialTodoState, action) => {
+  switch (action.type) {
+    case READ_TODO:
+      return { ...state, isLoading: true, isContentLoading: true };
+    case READ_TODO_SUCCESS:
+      return { ...state, isLoading: false, isContentLoading: false, todoItems: action.payload };
+    case READ_TODO_ERROR:
+      return { ...state, isLoading: false, isContentLoading: false, error: action.error };
+    case CREATE_TODO:
+      return { ...state, isLoading: true, isActionLoading: true };
+    case CREATE_TODO_SUCCESS:
+      return {
+        ...state, isLoading: false, isActionLoading: false,
+        todoItems: [...state.todoItems, action.payload],
+      };
+    // ...same pattern for TOGGLE_/UPDATE_/DELETE_ triples
+    default:
+      return state;
+  }
+};
+export default todo;
+```
+
+NgRx
+```typescript
+// templates/chota-angular-ngrx/src/app/state/todo/todo.reducer.ts
+import { createReducer, on } from '@ngrx/store';
+import initialTodoState from './todo.initial';
+import {
+  createTodo, editTodo, updateTodo, toggleTodo, deleteTodo, loadTodos,
+  loadTodosRequest, loadTodosSuccess, loadTodosFail,
+  addTodoRequest, addTodoSuccess, addTodoFail,
+} from './todo.actions';
+
+export const todoReducer = createReducer(
+  initialTodoState,
+
+  on(loadTodosRequest, (state) => ({ ...state, isContentLoading: true, error: '' })),
+  on(loadTodosSuccess, (state) => ({ ...state, isContentLoading: false })),
+  on(loadTodosFail, (state, { error }) => ({ ...state, isContentLoading: false, error })),
+  on(loadTodos, (state, { todos }) => ({ ...state, todoItems: todos })),
+
+  on(addTodoRequest, (state) => ({ ...state, isActionLoading: true, error: '' })),
+  on(addTodoSuccess, (state) => ({ ...state, isActionLoading: false })),
+  on(addTodoFail, (state, { error }) => ({ ...state, isActionLoading: false, error })),
+
+  on(createTodo, (state, { id, text }) => ({
+    ...state,
+    todoItems: [...state.todoItems, { id, text, completed: false }],
+  })),
+
+  on(editTodo, (state, payload) => ({ ...state, currentTodoItem: payload })),
+
+  on(toggleTodo, (state, { id }) => ({
+    ...state,
+    todoItems: state.todoItems.map((t) =>
+      t.id === id ? { ...t, completed: !t.completed } : t),
+  })),
+);
+```
+
+{::nomarkdown}</div>{:/}
+
+Across all four tabs the *contract* is the same: given the previous state and an action, return a new state. The surface differs in whether you write the switch yourself (Classic Redux / Saga), let a library auto-generate the switch from handlers (NgRx, RTK), or dispense with the whole pattern in favour of store-method mutations (Pinia — see the `Store` docs).
 
 ### Practical Example: CRUD Operations Reducer
 

--- a/docs/state/selectors.md
+++ b/docs/state/selectors.md
@@ -29,26 +29,114 @@ Key aspects of selectors:
 
 ## Code Examples
 
-### Basic Example: Simple Selectors
+### Basic Example: getVisibleTodos across state libraries
 
+The same derived selector — give me the filtered set of visible todos — across four state libraries. Classic Redux, Redux Saga, and WC-Saga all use the same plain-function selector (Saga templates share this exact file). Pinia exposes it as a getter on the store. NgRx composes memoized selectors via `createSelector`.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Classic Redux
 ```javascript
-// selectors.js - Basic state extraction
-const selectTodos = (state) => state.todos.items;
-const selectTodosLoading = (state) => state.todos.loading;
-const selectTodosFilter = (state) => state.todos.filter;
+// templates/chota-react-redux/src/state/todo/todo.selectors.js
+// Plain selector function. The React-Saga and WC-Saga templates ship the
+// same file — the selector pattern is independent of the middleware.
+import { SHOW_ACTIVE, SHOW_ALL, SHOW_COMPLETED } from "../filters/filters.type";
 
-// Component usage
-import { useSelector } from 'react-redux';
-
-function TodoList() {
-  const todos = useSelector(selectTodos);
-  const loading = useSelector(selectTodosLoading);
-  
-  if (loading) return <Spinner />;
-  
-  return todos.map(todo => <TodoItem key={todo.id} todo={todo} />);
-}
+export const getVisibleTodos = (todo, filter) => {
+  let visibleTodos = [];
+  switch (filter) {
+    case SHOW_ALL:       visibleTodos = todo.todoItems; break;
+    case SHOW_COMPLETED: visibleTodos = todo.todoItems.filter((t) => t.completed); break;
+    case SHOW_ACTIVE:    visibleTodos = todo.todoItems.filter((t) => !t.completed); break;
+    default:             throw new Error("Unknown filter: " + filter);
+  }
+  return { ...todo, todoItems: visibleTodos };
+};
 ```
+
+Redux Toolkit
+```javascript
+// templates/chota-react-rtk/src/state/todo/todo.selectors.js
+// RTK doesn't add a selector layer of its own for the basic case — you
+// write a plain selector the same way. Reach for `createSelector`
+// (re-exported from RTK) when you need memoization for expensive shapes.
+import { SHOW_ACTIVE, SHOW_ALL, SHOW_COMPLETED } from "../filters/filters.type";
+
+export const getVisibleTodos = (todo, filter) => {
+  switch (filter) {
+    case SHOW_ALL:       return { ...todo };
+    case SHOW_COMPLETED: return { ...todo, todoItems: todo.todoItems.filter((t) => t.completed) };
+    case SHOW_ACTIVE:    return { ...todo, todoItems: todo.todoItems.filter((t) => !t.completed) };
+    default:             return todo;
+  }
+};
+
+// With memoization:
+// export const getVisibleTodos = createSelector(
+//   [(state) => state.todo, (state) => state.filters],
+//   (todo, filters) => { /* ...same logic... */ }
+// );
+```
+
+NgRx
+```typescript
+// templates/chota-angular-ngrx/src/app/state/todo/todo.selectors.ts
+// createSelector composes input selectors into a memoized output selector.
+// The combiner only re-runs when an input selector returns a new reference.
+import { createSelector } from '@ngrx/store';
+import { AppState } from '../index';
+import { getSelectedFilter } from '../filters/filters.selectors';
+
+export const getTodoState = (state: AppState) => state.todo;
+
+export const getVisibleTodos = createSelector(
+  getTodoState,
+  getSelectedFilter,
+  (todoState, selectedFilter) => {
+    const { todoItems } = todoState;
+    switch (selectedFilter?.id) {
+      case 'SHOW_COMPLETED':
+        return { ...todoState, todoItems: todoItems.filter((t) => t.completed) };
+      case 'SHOW_ACTIVE':
+        return { ...todoState, todoItems: todoItems.filter((t) => !t.completed) };
+      default:
+        return todoState;
+    }
+  }
+);
+```
+
+Pinia
+```javascript
+// templates/chota-vue-pinia/src/state/todo/index.js
+// Pinia "selectors" are getters on the store — functions of state that
+// Vue's reactivity system caches automatically. The selector function
+// itself lives in todo.selectors.js and is reused from the getter.
+import { defineStore } from 'pinia';
+import { getVisibleTodos } from './todo.selectors';
+import { useFiltersStore } from '../filters';
+import { getSelectedFilter } from '../filters/filters.selectors';
+
+export const useTodoStore = defineStore('todo', {
+  state: () => ({ /* ...intialTodoState */ }),
+  getters: {
+    visibleTodos(state) {
+      const filtersData = useFiltersStore();
+      const selectedFilter = getSelectedFilter(filtersData);
+      return getVisibleTodos(state, selectedFilter.id);
+    },
+  },
+});
+
+// templates/chota-vue-pinia/src/state/todo/todo.selectors.js
+export const getVisibleTodos = (todo, filter) => {
+  /* same switch on filter as the Redux tab */
+};
+```
+
+{::nomarkdown}</div>{:/}
+
+The takeaway: the *derivation* — "apply the active filter to the todo list" — is the same pure function everywhere. What changes is how each library wires memoization and subscription. Redux-family templates use plain functions and optionally opt into `createSelector`. NgRx uses `createSelector` as the default path so every output selector is memoized. Pinia uses Vue's reactivity (a getter on the store) and reuses the same plain selector internally.
 
 ### Practical Example: Memoized Selectors with Reselect
 

--- a/docs/state/store.md
+++ b/docs/state/store.md
@@ -45,80 +45,115 @@ By using a store, developers can more easily manage complex application states, 
 
 ## Code Examples
 
-### Basic Example: Simple Redux Store
+### Basic Example: Store bootstrap across state libraries
 
-A fundamental store implementation demonstrating core concepts:
+Each `chota-*` template configures its store in the smallest possible way. The React-Saga and WC-Saga templates share the same saga-backed setup because the saga pattern is framework-agnostic, so only one is shown.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+Classic Redux
 ```javascript
-// store.js - Basic Redux store
+// templates/chota-react-redux/src/state/index.js
+import { createStore } from "redux";
+import reducer from "./rootReducer";
 
-import { createStore } from 'redux';
-
-// Initial state shape
-const initialState = {
-  user: null,
-  theme: 'light',
-  notifications: []
-};
-
-// Reducer - Pure function that updates state
-const rootReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case 'SET_USER':
-      return { ...state, user: action.payload };
-    
-    case 'TOGGLE_THEME':
-      return { 
-        ...state, 
-        theme: state.theme === 'light' ? 'dark' : 'light' 
-      };
-    
-    case 'ADD_NOTIFICATION':
-      return {
-        ...state,
-        notifications: [...state.notifications, action.payload]
-      };
-    
-    case 'CLEAR_NOTIFICATIONS':
-      return { ...state, notifications: [] };
-    
-    default:
-      return state;
-  }
-};
-
-// Create store
-const store = createStore(rootReducer);
+const store = createStore(
+  reducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
 
 export default store;
 ```
 
-Usage in components:
+Redux Toolkit
+```javascript
+// templates/chota-react-rtk/src/state/index.js
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "./rootReducer";
 
-```jsx
-// App.js - Connect components to store
+const store = configureStore({
+  reducer: rootReducer,
+  // DevTools and thunk middleware are wired automatically by configureStore.
+});
 
-import React from 'react';
-import { Provider, useSelector, useDispatch } from 'react-redux';
-import store from './store';
-
-const ThemeToggle = () => {
-  const theme = useSelector(state => state.theme);
-  const dispatch = useDispatch();
-
-  return (
-    <button onClick={() => dispatch({ type: 'TOGGLE_THEME' })}>
-      Current: {theme}
-    </button>
-  );
-};
-
-const App = () => (
-  <Provider store={store}>
-    <ThemeToggle />
-  </Provider>
-);
+export default store;
 ```
+
+Redux Saga
+```javascript
+// templates/chota-react-saga/src/state/index.js
+// (Identical setup in templates/chota-wc-saga/src/state/index.js —
+// sagas don't care whether the UI is React or Web Components.)
+import { composeWithDevTools } from "@redux-devtools/extension";
+import { createStore, applyMiddleware } from "redux";
+import createSagaMiddleware from "redux-saga";
+import reducer from "./rootReducer";
+import sagas from "./rootSagas";
+
+const sagaMiddleware = createSagaMiddleware();
+const enhancer = applyMiddleware(sagaMiddleware);
+const composedEnhancers = composeWithDevTools(enhancer);
+
+const store = createStore(reducer, composedEnhancers);
+sagaMiddleware.run(sagas);
+
+export default store;
+```
+
+NgRx
+```typescript
+// templates/chota-angular-ngrx/src/app/app.config.ts
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideStore } from '@ngrx/store';
+import { provideEffects } from '@ngrx/effects';
+import { provideStoreDevtools } from '@ngrx/store-devtools';
+import { reducers } from './state';
+import { TodoEffects } from './state/todo/todo.effects';
+import { environment } from '../environments/environment';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideStore(reducers),
+    provideEffects([TodoEffects]),
+    provideStoreDevtools({ maxAge: 25, logOnly: environment.production }),
+  ],
+};
+```
+
+Pinia
+```javascript
+// templates/chota-vue-pinia/src/state/todo/index.js
+// Pinia has no single root "store" — each defineStore() is its own
+// self-contained store with state / getters / actions, wired on the app
+// via app.use(createPinia()) in main.ts.
+import { defineStore, acceptHMRUpdate } from 'pinia';
+import { addTodos, deleteTodos, getTodos, updateTodos, updateToggleTodos } from './todo.operations';
+import intialTodoState from './todo.initial';
+import { getVisibleTodos } from './todo.selectors';
+import { editTodo } from './todo.actions';
+import { useFiltersStore } from '../filters';
+import { getSelectedFilter } from '../filters/filters.selectors';
+
+export const useTodoStore = defineStore('todo', {
+  state: () => ({ ...intialTodoState }),
+  getters: {
+    visibleTodos: (state) => {
+      const filtersData = useFiltersStore();
+      return getVisibleTodos(state, getSelectedFilter(filtersData).id);
+    },
+  },
+  actions: { getTodos, addTodos, editTodo, updateTodos, updateToggleTodos, deleteTodos },
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useTodoStore, import.meta.hot));
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+Each tab is the full store bootstrap straight from the corresponding template — real imports, real enhancers, real devtools wiring. The Redux family shares the `createStore` primitive (or `configureStore` as its opinionated wrapper). NgRx provides the same store via Angular DI. Pinia throws out the notion of one central store entirely: every `defineStore` call is a store in its own right, and the store tree emerges from which stores a component happens to use.
 
 ### Practical Example: Store with Middleware and DevTools
 

--- a/docs/ui/atom.md
+++ b/docs/ui/atom.md
@@ -28,54 +28,136 @@ In the Universal Frontend Architecture, atoms bridge the gap between design and 
 
 ## Code Examples
 
-### Basic Example: Simple Button Atom
+### Basic Example: Button Atom across frameworks
 
-A fundamental button atom demonstrating single-purpose design:
+Here's the same single-purpose Button atom pulled directly from each `chota-*` template. The shape is intentionally identical across all four: one prop-driven button that swaps to a `Loader` while `isLoading` is true, and emits a click otherwise. Compare how each framework expresses the same pattern.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// Button.js
+// templates/chota-react-redux/src/ui/atoms/Button/Button.component.jsx
+import Loader from "../Loader/Loader.component";
+import './Button.style.css';
 
-import React from "react";
-
-const Button = ({ onClick, label }) => {
-  return <button onClick={onClick}>{label}</button>;
-};
-
-export default Button;
+export default function Button(props) {
+  const transformedProps = { ...props };
+  delete transformedProps.isLoading;
+  if (props.isLoading) {
+    return (
+      <button {...transformedProps} className={`${props.className} loading-button`}>
+        <Loader width="2px" size="1.2rem" color="#fff" />
+      </button>
+    );
+  }
+  return <button {...transformedProps}>{props.children}</button>;
+}
 ```
 
-In this example, the Button component is a basic building block (atom) that takes two props:
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Button/Button.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import LoaderComponent from '../Loader/Loader.component';
 
-- `onClick`: a function to be called when the button is clicked.
-- `label`: the text content of the button.
+@Component({
+  selector: 'app-button',
+  standalone: true,
+  imports: [LoaderComponent],
+  templateUrl: './Button.component.html',
+  styleUrls: ['./Button.style.css'],
+})
+export default class ButtonComponent {
+  @Input() isLoading = false;
+  @Input() classes?: string;
+  @Input() type = '';
 
-This simple Button component can be reused throughout the application wherever a button is needed. When combining multiple atoms like this, we can start building more complex components (molecules, organisms, etc.) by composing them together.
+  get computedClasses() {
+    return this.isLoading ? `${this.classes} loading-button` : this.classes;
+  }
 
-Here's an example of how we might use this Button component in a parent component:
-
-```jsx
-// App.js
-
-import React from "react";
-import Button from "./Button";
-
-const App = () => {
-  const handleClick = () => {
-    alert("Button clicked!");
-  };
-
-  return (
-    <div>
-      <h1>My App</h1>
-      <Button onClick={handleClick} label="Click me" />
-    </div>
-  );
-};
-
-export default App;
+  @Output() onClick = new EventEmitter<Event>();
+}
 ```
 
-In this example, the `App` component uses the `Button` atom by passing in an `onClick` function and a `label`. This follows the Atomic Design principles of building up more complex components by combining simpler ones.
+```html
+<!-- Button.component.html -->
+@if (isLoading) {
+  <button [class]="computedClasses" [disabled]="isLoading">
+    <app-loader width="2px" size="1.2rem" color="#fff"></app-loader>
+  </button>
+} @else {
+  <button [type]="type || 'button'" (click)="onClick.emit($event)" [class]="computedClasses">
+    <ng-content></ng-content>
+  </button>
+}
+```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Button/Button.component.vue -->
+<template>
+  <button v-if="isLoading" :disabled="disabled" @click="$emit('onClick')" :class="getButtonClass()">
+    <Loader width="2px" size="1.2rem" color="#fff" />
+  </button>
+  <button v-else :disabled="disabled" :type="type" @click="$emit('onClick')" :class="getButtonClass()">
+    <slot />
+  </button>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+import Loader from '../Loader/Loader.component.vue';
+
+export default defineComponent({
+  components: { Loader },
+  props: ['isLoading', 'class', 'disabled', 'onClick', 'label', 'type'],
+  methods: {
+    getButtonClass() {
+      return `${this.class} loading-button`;
+    },
+  },
+})
+</script>
+
+<style scoped src="./Button.style.css"></style>
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Button/Button.component.js
+import { html } from "lit";
+import style from './Button.style';
+import "../Loader/app-loader";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+import emit from "../../../utils/events/emit";
+
+export default function Button(props) {
+  useComputedStyles(this, [style]);
+  if (props.isLoading) {
+    return html`
+      <button type="button" class=${`${props.classes} loading-button`}>
+        <app-loader .width=${'2px'} .size=${'1.2rem'} .color=${'#fff'}>Loading...</app-loader>
+      </button>
+    `;
+  }
+  return html`
+    <button type="button"
+      class="${props.classes}"
+      @click="${() => emit(this, "onClick", props)}">
+      <slot></slot>
+    </button>
+  `;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+A few things worth comparing across the tabs:
+
+- **Children projection.** React uses `{props.children}`, Angular uses `<ng-content>`, Vue and Web Components both use `<slot>` — four spellings of the same idea.
+- **Event shape.** React passes `onClick` through as a plain prop. Angular exposes an `@Output() EventEmitter`. Vue emits `'onClick'` via `$emit`. The Lit-based WC uses a tiny `emit(this, "onClick", props)` helper wrapping `CustomEvent`.
+- **Styling.** Every template co-locates `Button.style.css` next to the component; Angular and Vue scope it, React imports it side-effect style, WC injects via `useComputedStyles`.
 
 ### Advanced Example: Icon Atom with Dynamic SVG Loading
 

--- a/docs/ui/attributes.md
+++ b/docs/ui/attributes.md
@@ -30,49 +30,158 @@ Key categories of attributes:
 
 ## Code Examples
 
-### Basic Example: Boolean and Standard Attributes
+### Basic Example: Setting attributes across frameworks
+
+The same Input atom across the four UI templates: take props (`id`, `name`, `type`, `value`, `disabled`, `placeholder`, `checked`) and lay them onto a real `<input>` element. Each framework has its own answer to "is this an HTML attribute or a DOM property?" — the answers diverge most visibly for `value` and `checked`, which need property binding to track user input.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
+```jsx
+// templates/chota-react-redux/src/ui/atoms/Input/Input.component.jsx
+// React decides at runtime whether to set an attribute or a property
+// for each prop on the JSX element. `value` and `checked` are properties;
+// `placeholder`, `type`, `id`, `name` are attributes. Spread does both.
+export default function Input(props) {
+  let id = props.id;
+  if (!id) id = Math.random();
+  return (
+    <>
+      <label htmlFor={id} className="sr-only">
+        {props.name || "Some Label"}
+      </label>
+      <input {...props} id={id} />
+    </>
+  );
+}
+```
+
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Input/Input.component.ts
+// Angular distinguishes attribute binding ([attr.x]="...") from property
+// binding ([x]="..."). Property is the default; the @HostBinding here
+// reflects the inner type onto the host element only when no [type] is
+// explicitly bound from the parent.
+import { Component, Input, Output, EventEmitter, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'app-input',
+  standalone: true,
+  templateUrl: './Input.component.html',
+  styleUrls: ['./Input.style.css'],
+})
+export default class InputComponent {
+  @HostBinding('attr.type') externalType: string | null = '';
+
+  @Input() set type(value: string) { this._type = value; this.externalType = null; }
+  get type() { return this._type; }
+  private _type = '';
+
+  @Input() id = '';
+  @Input() name = '';
+  @Input() value = '';
+  @Input() checked = false;
+  @Input() disabled = false;
+  @Input() placeholder = '';
+
+  @Output() onInput = new EventEmitter<Event>();
+  onInputHandler(e: Event) { this.onInput.emit(e); }
+}
+```
 
 ```html
-<!-- Boolean Attributes -->
-<input type="text" required>  <!-- required=true (attribute present) -->
-<input type="checkbox" checked>  <!-- checked=true -->
-<button disabled>Submit</button>  <!-- disabled=true -->
-<input type="text" readonly value="Cannot edit">  <!-- readonly=true -->
+<!-- Input.component.html -->
+<label [for]="id" class="sr-only">{{ name || 'Some Label' }}</label>
+<input
+  [id]="id"
+  [type]="type"
+  [value]="value"
+  [checked]="checked"
+  [disabled]="disabled"
+  [placeholder]="placeholder"
+  (input)="onInputHandler($event)"
+/>
+```
 
-<!-- Valid boolean attribute syntax -->
-<input required>  <!-- Recommended: no value -->
-<input required="">  <!-- Valid: empty string -->
-<input required="required">  <!-- Valid but verbose -->
-
-<!-- INVALID boolean syntax -->
-<input required="false">  <!-- Still true! Attribute is present -->
-<input required="0">  <!-- Still true! -->
-
-<!-- Standard Attributes -->
-<img src="photo.jpg" alt="Description" width="300" height="200">
-<a href="https://example.com" target="_blank" rel="noopener">Link</a>
-<input type="email" name="email" placeholder="Enter email" maxlength="50">
-
-<!-- Global Attributes -->
-<div id="unique-id" class="container active" title="Hover tooltip">
-  <p lang="en" dir="ltr" tabindex="0">Text content</p>
-</div>
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Input/Input.component.vue -->
+<!-- :prop is shorthand for v-bind:prop. Vue chooses attribute vs property
+     automatically (DOM attributes by default, switching to property for
+     known cases like value/checked/innerHTML). -->
+<template>
+  <input
+    :id="id"
+    :name="name"
+    :type="type || 'text'"
+    :disabled="disabled"
+    :alt="alt"
+    :placeholder="placeholder"
+    :class="getImageClass()"
+    @click="$emit('onClick', $event)"
+    @input="$emit('onInput', $event)"
+    :value="value"
+    :checked="checked"
+  />
+</template>
 
 <script>
-  // Accessing attributes via JavaScript
-  const input = document.querySelector('input[required]');
-  
-  // getAttribute/setAttribute (works with attributes)
-  console.log(input.getAttribute('required'));  // "" (empty string)
-  console.log(input.hasAttribute('required'));  // true
-  input.removeAttribute('required');
-  input.setAttribute('required', '');  // Set back
-  
-  // Property access (works with DOM properties)
-  console.log(input.required);  // true (boolean)
-  input.required = false;  // Remove via property
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  props: ['id', 'name', 'type', 'value', 'disabled', 'placeholder', 'alt', 'class', 'onInput', 'onClick', 'checked'],
+  methods: {
+    getImageClass() { return `${this.class}`; },
+  },
+});
 </script>
 ```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Input/Input.component.js
+// Lit makes the attribute-vs-property distinction explicit:
+//   foo=${...}       sets an attribute (everything stringifies)
+//   .foo=${...}      sets a JS property (preserves type, required for
+//                     value/checked because they diverge from attributes
+//                     once the user types)
+//   ?foo=${...}      sets a boolean attribute
+//   @foo=${...}      attaches an event listener
+import { html } from "lit";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+import style from './Input.style';
+import emit from "../../../utils/events/emit";
+
+export default function Input(props) {
+  useComputedStyles(this, [style]);
+  let id = props.id;
+  if (!id) id = Math.random();
+  return html`
+    <label htmlFor=${id} class="sr-only">
+      ${props.name || "Some Label"}
+    </label>
+    <input
+      type=${props.type}
+      .value=${props.value}
+      .checked=${props.checked}
+      id=${props.id}
+      name=${props.name}
+      placeholder=${props.placeholder}
+      @change=${(e) => emit(this, "onChange", e)}
+      @input=${(e) => emit(this, "onInput", e)}
+    />
+  `;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+Three things the tabs make obvious:
+
+- **Property-vs-attribute is real and matters most for `value` / `checked` / `disabled`.** All four templates make sure those go on as *properties*, not attributes — otherwise the input won't track user input correctly. React handles it implicitly, Angular's `[value]` is property binding, Vue's `:value` defers to its known cases, Lit asks you to be explicit with the `.` prefix.
+- **Boolean attributes diverge from boolean properties.** `<input disabled>` (attribute present = true) vs `el.disabled = true` (property). Setting `disabled="false"` as an attribute is the classic footgun — the attribute is present, so the input is disabled regardless of value.
+- **Event handlers are sometimes attributes, often properties, never inline.** Inline `onclick="..."` was deprecated long ago. Each framework wires events through its native channel (synthetic event for React, `(event)` binding for Angular, `@event` for Vue, `@event=${}` for Lit) — but they all resolve to `addEventListener` under the hood.
 
 ### Practical Example: Data Attributes and Custom Metadata
 

--- a/docs/ui/component.md
+++ b/docs/ui/component.md
@@ -27,59 +27,169 @@ In the context of the [Atomic Design](atomic-design.html) system, components exi
 
 ## Code Examples
 
-### Basic Example: Native Web Component
+### Basic Example: Alert component across frameworks
 
-A fundamental custom element demonstrating core component principles:
+A component is anything that combines markup, styling, and behaviour behind a single name. Here's the same `Alert` atom — props for `variant`, `show`, `message`, an internal boolean, a `useEffect`-style sync with the `show` prop, and a close handler that emits upward — implemented once in each of the `chota-*` templates.
 
-Web Components consist of three main technologies: Custom Elements, Shadow DOM, and HTML Templates.
+{::nomarkdown}<div class="code-tabs">{:/}
 
-Here's a simple example of a Web Component using Custom Elements:
+React
+```jsx
+// templates/chota-react-redux/src/ui/atoms/Alert/Alert.component.jsx
+import React, { useEffect, useState } from "react";
+import "./Alert.style.css";
+import IconButton from "../IconButton/IconButton.component";
+import Image from "../Image/Image.component";
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Custom Button Component</title>
-  </head>
-  <body>
-    <!-- Define the custom button component -->
-    <script>
-      class CustomButton extends HTMLElement {
-        constructor() {
-          super();
+export default function Alert({ variant, show, message, onCloseClick }) {
+  const [showAlert, setShowAlert] = useState(show);
 
-          // Create a shadow root
-          this.attachShadow({ mode: "open" });
+  const handleClose = (e) => {
+    setShowAlert(false);
+    if (onCloseClick) onCloseClick(e);
+  };
 
-          // Define the button element
-          const button = document.createElement("button");
-          button.textContent = "Click me!";
-          button.addEventListener("click", () => alert("Button clicked!"));
+  useEffect(() => { setShowAlert(show); }, [show]);
 
-          // Append the button to the shadow DOM
-          this.shadowRoot.appendChild(button);
-        }
-      }
-
-      // Register the custom element
-      customElements.define("custom-button", CustomButton);
-    </script>
-
-    <!-- Use the custom button component -->
-    <custom-button></custom-button>
-  </body>
-</html>
+  return showAlert ? (
+    <div className={`bg-${variant === "error" ? "error" : "primary"} text-white alert`}>
+      <div className="message">
+        <Image src={`https://icongr.am/feather/${
+          variant === "error" ? "alert-triangle" : "info"
+        }.svg?size=24&color=ffffff`} alt={variant} />
+        <span>{message}</span>
+      </div>
+      <IconButton variant="clear" alt="close" color="ffffff" iconName="x" size="16" onClick={handleClose} />
+    </div>
+  ) : null;
+}
 ```
 
-- The `CustomButton` class extends `HTMLElement` to create a custom element.
-- The `constructor` method is used to define the behavior of the custom element.
-- `this.attachShadow({ mode: 'open' })` creates a shadow DOM for encapsulating the component's styles and functionality.
-- A button element is created and added to the shadow DOM.
-- The custom element is registered using `customElements.define('custom-button', CustomButton)`.
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Alert/Alert.component.ts
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import ImageComponent from '../Image/Image.component';
+import IconButtonComponent from '../IconButton/IconButton.component';
 
-In the HTML body, `<custom-button></custom-button>` is used to insert an instance of the custom button component.
+@Component({
+  selector: 'app-alert',
+  standalone: true,
+  imports: [ImageComponent, IconButtonComponent],
+  templateUrl: './Alert.component.html',
+  styleUrls: ['./Alert.style.css'],
+})
+export default class AlertComponent implements OnChanges {
+  @Input() show = false;
+  @Input() variant?: string;
+  @Input() message = '';
+  @Output() onCloseClick = new EventEmitter<Event>();
+
+  showAlert = false;
+
+  get classes() {
+    return `bg-${this.variant === 'error' ? 'error' : 'primary'} text-white alert`;
+  }
+  get src() {
+    return `https://icongr.am/feather/${
+      this.variant === 'error' ? 'alert-triangle' : 'info'
+    }.svg?size=24&color=ffffff`;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['show']) this.showAlert = changes['show'].currentValue;
+  }
+
+  handleClose(e: Event) {
+    this.showAlert = false;
+    this.onCloseClick.emit(e);
+  }
+}
+```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Alert/Alert.component.vue -->
+<template>
+  <div v-if="showAlert" :class="getVariantClass()">
+    <div class="message">
+      <Image :src="getImageSrc()" alt="variant" />
+      <span>{{ message }}</span>
+    </div>
+    <IconButton variant="clear" alt="close" color="ffffff"
+                iconName="x" size="16" @onClick="handleClose" />
+  </div>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+import Image from "../Image/Image.component.vue";
+import IconButton from "../IconButton/IconButton.component.vue";
+
+export default defineComponent({
+  components: { Image, IconButton },
+  props: ['show', 'message', 'variant', 'onCloseClick'],
+  data() { return { showAlert: this.show }; },
+  watch: { show(v) { this.showAlert = v; } },
+  methods: {
+    getVariantClass() {
+      return `bg-${this.variant === 'error' ? 'error' : 'primary'} text-white alert`;
+    },
+    getImageSrc() {
+      return `https://icongr.am/feather/${
+        this.variant === 'error' ? 'alert-triangle' : 'info'
+      }.svg?size=24&color=ffffff`;
+    },
+    handleClose(e) {
+      this.showAlert = false;
+      this.$emit('onCloseClick', e);
+    },
+  },
+});
+</script>
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Alert/Alert.component.js
+import { html, useEffect, useState } from "haunted";
+import style from "./Alert.style";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+import '../IconButton/app-icon-button';
+import '../Image/app-image';
+import emit from "../../../utils/events/emit";
+
+export default function Alert({ variant, show, message }) {
+  useComputedStyles(this, [style]);
+  const [showAlert, setShowAlert] = useState(show);
+
+  const handleClose = (e) => {
+    setShowAlert(false);
+    emit(this, "onCloseClick", e);
+  };
+
+  useEffect(() => { setShowAlert(show); }, [show]);
+
+  return showAlert ? html`
+    <div class=${`bg-${
+      variant === "error" ? "error" : "primary"
+    } text-white alert`}>
+      <div class="message">
+        <app-image .src=${`https://icongr.am/feather/${
+          variant === "error" ? "alert-triangle" : "info"
+        }.svg?size=24&color=ffffff`} alt=${variant}></app-image>
+        <span>${message}</span>
+      </div>
+      <app-icon-button .variant=${"clear"} .alt=${"close"} .color=${"ffffff"}
+                       .iconName=${"x"} .size=${"16"} @onClick=${handleClose}></app-icon-button>
+    </div>
+  ` : null;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+A component is the same idea in every flavour — a named unit that owns markup, a tiny bit of local state, a reaction to prop changes, and an event it broadcasts to whatever parent is listening. Each framework's ceremony differs (`useState` / class fields / `data()` + `watch` / haunted's `useState` + `emit` helper) but the *shape* — what goes in, what renders, what goes out — is preserved across all four.
 
 ### Practical Example: React Component with State and Props
 

--- a/docs/ui/events.md
+++ b/docs/ui/events.md
@@ -29,70 +29,102 @@ Key characteristics of events:
 
 ## Code Examples
 
-### Basic Example: Event Listeners and Handlers
+### Basic Example: Click + form events across frameworks
+
+A click event is one idea with four spellings. Here is the same "dispatch an `onClick` when the user presses the Button atom" wiring taken straight from each `chota-*` template.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
+```jsx
+// templates/chota-react-redux/src/ui/atoms/Button/Button.component.jsx
+// React passes handlers as props. camelCase `onClick` is the React-specific
+// synthetic event; native DOM behaviour still bubbles underneath.
+export default function Button(props) {
+  const transformedProps = { ...props };
+  delete transformedProps.isLoading;
+  if (props.isLoading) { /* loading state */ }
+  return <button {...transformedProps}>{props.children}</button>;
+}
+
+// Usage:
+<Button onClick={(e) => handleClick(e)}>Save</Button>
+```
+
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Button/Button.component.ts
+// @Output + EventEmitter is Angular's way of exposing "custom events"
+// to the parent. The template binds (click) to call emit.
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+
+@Component({ selector: 'app-button', /* ... */ })
+export default class ButtonComponent {
+  @Input() isLoading = false;
+  @Output() onClick = new EventEmitter<Event>();
+}
+```
 
 ```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>JavaScript Event Example</title>
-  </head>
-  <body>
-    <button id="myButton">Click me</button>
-    <input type="text" id="myInput" placeholder="Type something..." />
-    
-    <script>
-      // Click event
-      const button = document.getElementById("myButton");
-      
-      function handleClick(event) {
-        console.log('Button clicked!');
-        console.log('Event type:', event.type);
-        console.log('Target element:', event.target);
-        console.log('Timestamp:', event.timeStamp);
-      }
-      
-      button.addEventListener("click", handleClick);
-      
-      // Keyboard events
-      const input = document.getElementById("myInput");
-      
-      input.addEventListener("keydown", (event) => {
-        console.log('Key pressed:', event.key);
-        console.log('Key code:', event.code);
-        
-        // Detect special keys
-        if (event.key === 'Enter') {
-          console.log('Enter key pressed!');
-        }
-        
-        if (event.ctrlKey && event.key === 's') {
-          event.preventDefault();  // Prevent browser save dialog
-          console.log('Ctrl+S pressed - custom save action');
-        }
-      });
-      
-      // Input event (fires on every change)
-      input.addEventListener("input", (event) => {
-        console.log('Current value:', event.target.value);
-      });
-      
-      // Focus and blur events
-      input.addEventListener("focus", () => {
-        console.log('Input focused');
-        input.style.borderColor = 'blue';
-      });
-      
-      input.addEventListener("blur", () => {
-        console.log('Input lost focus');
-        input.style.borderColor = '';
-      });
-    </script>
-  </body>
-</html>
+<!-- Button.component.html -->
+<button [type]="type || 'button'"
+        (click)="onClick.emit($event)"
+        [class]="computedClasses">
+  <ng-content></ng-content>
+</button>
+
+<!-- Parent usage -->
+<app-button (onClick)="handleClick($event)">Save</app-button>
 ```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Button/Button.component.vue -->
+<template>
+  <button :disabled="disabled" :type="type"
+          @click="$emit('onClick')"
+          :class="getButtonClass()">
+    <slot />
+  </button>
+</template>
+
+<!-- Parent usage -->
+<!-- <Button @onClick="handleClick">Save</Button> -->
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Button/Button.component.js
+// The WC templates use a tiny emit() helper that dispatches a CustomEvent.
+// Parents listen with addEventListener or Lit's @onClick= directive.
+import { html } from "lit";
+import emit from "../../../utils/events/emit";
+
+export default function Button(props) {
+  return html`
+    <button type="button"
+      class="${props.classes}"
+      @click="${() => emit(this, "onClick", props)}">
+      <slot></slot>
+    </button>
+  `;
+}
+
+// utils/events/emit.js (simplified):
+// export default function emit(host, name, detail) {
+//   host.dispatchEvent(new CustomEvent(name, {
+//     detail, bubbles: true, composed: true,
+//   }));
+// }
+
+// Parent usage:
+// <app-button @onClick=${(e) => handleClick(e.detail)}>Save</app-button>
+```
+
+{::nomarkdown}</div>{:/}
+
+The conceptual model is the same in every tab: the button's native `click` listener calls something that re-broadcasts to the parent under a framework-specific conduit. React uses the synthetic event system + prop functions. Angular wraps RxJS around `EventEmitter`. Vue uses a named `$emit`. Web Components use the browser's own `CustomEvent` bus. Parents subscribe in their respective idioms (`onClick={...}` / `(onClick)="..."` / `@onClick="..."` / `@onClick=${...}`) — but every one of those resolves to the same DOM click bubble under the hood.
+
 ### Practical Example: Event Propagation and Delegation
 
 ```html

--- a/docs/ui/molecule.md
+++ b/docs/ui/molecule.md
@@ -27,111 +27,198 @@ From a practical perspective, molecules reduce code duplication and enforce desi
 
 ## Code Examples
 
-### Basic Example: Search Bar Molecule
+### Basic Example: AddTodoForm molecule across frameworks
 
-A fundamental molecule combining input and button atoms:
+Each `chota-*` template ships a real `AddTodoForm` molecule that composes an `Input` atom and a `Button` atom into a single "add or update a task" pattern. Same contract — props for `buttonInfo`, `placeholder`, `isLoading`, `todoValue`; callbacks `onTodoAdd` / `onTodoUpdate` — four different native languages.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// SearchBar.js - Basic molecule
+// templates/chota-react-redux/src/ui/molecules/AddTodoForm/AddTodoForm.component.jsx
+import React, { useEffect, useState } from "react";
+import Input from "../../atoms/Input/Input.component";
+import Button from "../../atoms/Button/Button.component";
 
-import React from 'react';
-import Input from './atoms/Input';
-import Button from './atoms/Button';
-import Icon from './atoms/Icon';
-import './SearchBar.css';
-
-/**
- * SearchBar Molecule
- * Combines Input and Button atoms into a search interface
- */
-const SearchBar = ({ 
-  value, 
-  onChange, 
-  onSearch, 
-  placeholder = 'Search...',
-  disabled = false
+const AddTodoForm = ({
+  buttonInfo = { label: 'Add', variant: 'primary' },
+  placeholder, isLoading, onTodoAdd, onTodoUpdate, todoValue,
 }) => {
-  const handleKeyPress = (e) => {
-    if (e.key === 'Enter' && onSearch) {
-      onSearch(value);
-    }
-  };
+  const [inputValue, setInputValue] = useState(todoValue || '');
+  const { label, variant } = buttonInfo;
+
+  const handleChange = (e) => setInputValue(e.target.value);
+  useEffect(() => setInputValue(todoValue), [todoValue]);
 
   return (
-    <div className="search-bar">
-      <Icon name="search" className="search-bar__icon" />
-      <Input
-        type="text"
-        value={value}
-        onChange={onChange}
-        onKeyPress={handleKeyPress}
-        placeholder={placeholder}
-        disabled={disabled}
-        className="search-bar__input"
-      />
-      <Button
-        label="Search"
-        onClick={() => onSearch(value)}
-        disabled={disabled || !value}
-        variant="primary"
-        size="small"
-      />
+    <div>
+      <form role="form" onSubmit={(e) => {
+        e.preventDefault();
+        if (!inputValue.trim()) return;
+        todoValue ? onTodoUpdate(inputValue) : onTodoAdd(inputValue);
+        setInputValue('');
+      }}>
+        <div className="grouped">
+          <Input className="" value={inputValue} disabled={isLoading}
+                 placeholder={placeholder} onChange={handleChange} />
+          <Button className={`button ${variant}`} isLoading={isLoading} type="submit">
+            {label}
+          </Button>
+        </div>
+      </form>
     </div>
   );
 };
-
-export default SearchBar;
+export default AddTodoForm;
 ```
 
-```css
-/* SearchBar.css */
-.search-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  background: white;
-}
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/molecules/AddTodoForm/AddTodoForm.component.ts
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import InputComponent from '../../atoms/Input/Input.component';
+import ButtonComponent from '../../atoms/Button/Button.component';
 
-.search-bar__icon {
-  color: #666;
-}
+@Component({
+  selector: 'app-add-todo-form',
+  standalone: true,
+  imports: [InputComponent, ButtonComponent],
+  templateUrl: './AddTodoForm.component.html',
+  styleUrls: ['./AddTodoForm.style.css'],
+})
+export default class AddTodoFormComponent implements OnChanges {
+  @Input() buttonInfo = { variant: 'primary', label: 'Add' };
+  @Input() placeholder = 'Add your task';
+  @Input() isLoading = false;
+  @Input() todoValue = '';
 
-.search-bar__input {
-  flex: 1;
-  border: none;
-}
+  @Output() onTodoAdd = new EventEmitter<string>();
+  @Output() onTodoUpdate = new EventEmitter<string>();
 
-.search-bar__input:focus {
-  outline: none;
+  inputValue = '';
+  get buttonClasses() { return `button ${this.buttonInfo.variant}`; }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['todoValue']) this.inputValue = changes['todoValue'].currentValue || '';
+  }
+  onSubmit(e: Event) {
+    e.preventDefault();
+    const trimmed = this.inputValue.trim();
+    if (!trimmed) return;
+    if (this.todoValue) this.onTodoUpdate.emit(trimmed);
+    else this.onTodoAdd.emit(trimmed);
+  }
 }
 ```
 
-Usage:
+```html
+<!-- AddTodoForm.component.html -->
+<form (submit)="onSubmit($event)" class="add-todo-form">
+  <div class="grouped">
+    <app-input [value]="inputValue" [disabled]="isLoading"
+               [placeholder]="placeholder" (onChange)="handleChange($event)"></app-input>
+    <app-button [classes]="buttonClasses" [isLoading]="isLoading" type="submit">
+      {{ buttonInfo.label }}
+    </app-button>
+  </div>
+</form>
+```
 
-```jsx
-import React, { useState } from 'react';
-import SearchBar from './molecules/SearchBar';
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/molecules/AddTodoForm/AddTodoForm.component.vue -->
+<template>
+  <div>
+    <form @submit="onSubmit">
+      <div class="grouped">
+        <Input :value="inputValue" :disabled="isLoading"
+               :placeholder="placeholder" @onInput="handleChange" />
+        <Button :class="getButtonClass()" :isLoading="isLoading" type="submit">
+          {{ label }}
+        </Button>
+      </div>
+    </form>
+  </div>
+</template>
 
-const App = () => {
-  const [query, setQuery] = useState('');
+<script>
+import { defineComponent } from 'vue'
+import Input from '../../atoms/Input/Input.component.vue';
+import Button from '../../atoms/Button/Button.component.vue';
 
-  const handleSearch = (searchTerm) => {
-    console.log('Searching for:', searchTerm);
-    // Perform search logic
+export default defineComponent({
+  components: { Input, Button },
+  props: ['buttonInfo', 'placeholder', 'isLoading', 'onTodoAdd', 'onTodoUpdate', 'todoValue'],
+  data() {
+    return { label: 'Add', variant: 'primary', inputValue: '' };
+  },
+  watch: {
+    todoValue() { this.inputValue = this.todoValue; },
+    buttonInfo() {
+      this.label = this.buttonInfo.label;
+      this.variant = this.buttonInfo.variant;
+    }
+  },
+  methods: {
+    getButtonClass() { return `button ${this.variant}`; },
+    onSubmit(e) {
+      e.preventDefault();
+      if (!this.inputValue.trim()) return;
+      if (this.todoValue) this.$emit('onTodoUpdate', this.inputValue);
+      else this.$emit('onTodoAdd', this.inputValue);
+      this.inputValue = '';
+    },
+    handleChange(e) { this.inputValue = e.target.value; },
+  },
+})
+</script>
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/molecules/AddTodoForm/AddTodoForm.component.js
+import { html, useEffect, useState } from "haunted";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+import style from './AddTodoForm.style';
+import "../../atoms/Input/app-input";
+import "../../atoms/Button/app-button";
+import emit from "../../../utils/events/emit";
+
+function AddTodoForm({ buttonInfo, placeholder, isLoading, todoValue }) {
+  useComputedStyles(this, [style]);
+  const [inputValue, setInputValue] = useState(todoValue || '');
+  const { label, variant } = buttonInfo;
+
+  const handleChange = (e) => setInputValue(e.target.value);
+  useEffect(() => setInputValue(todoValue), [todoValue]);
+
+  const handleFormSubmit = (e) => {
+    if (e && e.preventDefault) e.preventDefault();
+    if (!inputValue.trim()) return;
+    if (todoValue) emit(this, 'onTodoUpdate', inputValue);
+    else emit(this, 'onTodoAdd', inputValue);
+    setInputValue('');
   };
 
-  return (
-    <SearchBar 
-      value={query}
-      onChange={(e) => setQuery(e.target.value)}
-      onSearch={handleSearch}
-    />
-  );
-};
+  return html`
+    <div>
+      <form @submit=${handleFormSubmit}>
+        <div class="grouped">
+          <app-input .value=${inputValue} .disabled=${isLoading}
+                     .placeholder=${placeholder} @onInput=${handleChange}></app-input>
+          <app-button .classes=${`button ${variant}`} .isLoading=${isLoading} type="submit">
+            ${label}
+          </app-button>
+        </div>
+      </form>
+    </div>
+  `;
+}
 ```
+
+{::nomarkdown}</div>{:/}
+
+Notice how the *composition* is identical — two atom children inside a `.grouped` wrapper with a submit handler — while the idiomatic surroundings change (`ngOnChanges` vs `watch` vs `useEffect`, `@Output` vs `$emit` vs `emit`, etc.). That is the whole point of organising UI at the molecule level: the shape is portable; the syntax is not.
 
 ### Practical Example: Form Field Molecule with Validation
 

--- a/docs/ui/organism.md
+++ b/docs/ui/organism.md
@@ -30,93 +30,192 @@ From a development workflow perspective, organisms are often the components that
 
 ## Code Examples
 
-### Basic Example: Header Organism
+### Basic Example: TodoList organism across frameworks
 
-Here is an example of an organism called `Header` that combines multiple molecules and atoms. The `Header` organism might consist of a `Logo` molecule, a `Navigation` molecule, and a `Button` atom for a user profile:
+A real organism pulled from the `chota-*` templates: `TodoList` assembles an `Alert` atom, an `AddTodoForm` molecule, `TodoItems` molecule and a `Skeleton` atom into a full "todo page body" region. It takes the entire slice of todo state as a prop plus an `events` bag of callbacks — it doesn't know or care that the state comes from Redux / NgRx / Pinia behind it.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// Header.js
+// templates/chota-react-redux/src/ui/organisms/TodoList/TodoList.component.jsx
+import Alert from "../../atoms/Alert/Alert.component";
+import AddTodoForm from "../../molecules/AddTodoForm/AddTodoForm.component";
+import TodoItems from "../../molecules/TodoItems/TodoItems.component";
+import Skeleton from "../../skeletons/Skeleton/Skeleton.component";
 
-import React from "react";
-import Logo from "./Logo";
-import Navigation from "./Navigation";
-import Button from "./Button";
-
-const Header = () => {
+export default function TodoList({ todoData, events }) {
+  const { onTodoCreate, onTodoEdit, onTodoUpdate, onTodoToggleUpdate, onTodoDelete } = events;
   return (
-    <header>
-      <Logo />
-      <Navigation />
-      <Button label="Profile" />
-    </header>
+    <>
+      {todoData.error ? (
+        <Alert variant="error" show={!!todoData.error} message={todoData.error} />
+      ) : null}
+      <AddTodoForm
+        todoValue={todoData.currentTodoItem.text || ""}
+        onTodoAdd={onTodoCreate}
+        onTodoUpdate={onTodoUpdate}
+        placeholder="Add your task"
+        isLoading={todoData.isActionLoading}
+        buttonInfo={{
+          label: todoData.currentTodoItem.text ? "Save" : "Add",
+          variant: "primary",
+        }}
+      />
+      {todoData.isContentLoading ? (
+        <>
+          <Skeleton height="24px" />
+          <Skeleton height="24px" />
+          <Skeleton height="24px" />
+        </>
+      ) : (
+        <TodoItems
+          todos={todoData.todoItems || []}
+          isDisabled={todoData.isActionLoading}
+          onToggleClick={onTodoToggleUpdate}
+          onDeleteClick={onTodoDelete}
+          onEditClick={onTodoEdit}
+        />
+      )}
+    </>
   );
-};
-
-export default Header;
+}
 ```
 
-In this example:
-
-- The `Header` organism is composed of the `Logo` molecule, `Navigation` molecule, and a `Button` atom for the user's profile.
-- Each of these components (`Logo`, `Navigation`, and `Button`) can be considered atoms or molecules on their own.
-
-Now, let's create the `Logo` and `Navigation` components:
-
-```jsx
-// Logo.js
-
-import React from "react";
-
-const Logo = () => {
-  return <div className="logo">My Logo</div>;
-};
-
-export default Logo;
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/organisms/TodoList/TodoList.component.ts
+@Component({
+  selector: 'app-todo-list',
+  standalone: true,
+  imports: [AlertComponent, AddTodoFormComponent, TodoItemsComponent, SkeletonComponent],
+  templateUrl: './TodoList.component.html',
+  styleUrls: ['./TodoList.style.css'],
+})
+export default class TodoListComponent {
+  @Input() todoData: TodoState = { /* initial defaults */ };
+  @Input() events = {
+    onTodoCreate: (text: string) => {},
+    onTodoEdit: (todo: any) => {},
+    onTodoUpdate: (text: string) => {},
+    onTodoToggleUpdate: (todo: any) => {},
+    onTodoDelete: (id: number) => {},
+  };
+  get buttonInfo() {
+    return {
+      label: this.todoData.currentTodoItem.text ? 'Save' : 'Add',
+      variant: 'primary',
+    };
+  }
+}
 ```
 
-```jsx
-// Navigation.js
-
-import React from "react";
-
-const Navigation = () => {
-  return (
-    <nav>
-      <ul>
-        <li>Home</li>
-        <li>About</li>
-        <li>Contact</li>
-      </ul>
-    </nav>
-  );
-};
-
-export default Navigation;
+```html
+<!-- TodoList.component.html -->
+@if (todoData.error) {
+  <app-alert variant="error" [show]="!!todoData.error" [message]="todoData.error"></app-alert>
+}
+<app-add-todo-form
+  [todoValue]="todoData.currentTodoItem.text || ''"
+  (onTodoAdd)="events.onTodoCreate($event)"
+  (onTodoUpdate)="events.onTodoUpdate($event)"
+  placeholder="Add your task"
+  [isLoading]="todoData.isActionLoading"
+  [buttonInfo]="buttonInfo"
+></app-add-todo-form>
+@if (todoData.isContentLoading) {
+  <app-skeleton height="24px"></app-skeleton>
+  <app-skeleton height="24px"></app-skeleton>
+  <app-skeleton height="24px"></app-skeleton>
+} @else {
+  <app-todo-items
+    [todos]="todoData.todoItems"
+    [isDisabled]="todoData.isActionLoading"
+    (onToggleClick)="events.onTodoToggleUpdate($event)"
+    (onDeleteClick)="events.onTodoDelete($event)"
+    (onEditClick)="events.onTodoEdit($event)"
+  ></app-todo-items>
+}
 ```
 
-In this setup, the `Logo` and `Navigation` components can be considered molecules, as they are composed of simpler atoms (e.g., a `div` for the logo and a list for navigation items).
-
-We can then use the Header organism in your application:
-
-```jsx
-// App.js
-
-import React from "react";
-import Header from "./Header";
-
-const App = () => {
-  return (
-    <div>
-      <Header />
-      {/* Other content goes here */}
-    </div>
-  );
-};
-
-export default App;
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/organisms/TodoList/TodoList.component.vue -->
+<template>
+  <div>
+    <Alert v-if="todoData.error" variant="error" :show="!!todoData.error" :message="todoData.error" />
+    <AddTodoForm
+      :todoValue="todoData.currentTodoItem.text || ''"
+      @onTodoAdd="events.onTodoCreate"
+      @onTodoUpdate="events.onTodoUpdate"
+      placeholder="Add your task"
+      :isLoading="todoData.isActionLoading"
+      :buttonInfo="getButtonInfo()"
+    />
+    <template v-if="todoData.isContentLoading">
+      <Skeleton height="24px" />
+      <Skeleton height="24px" />
+      <Skeleton height="24px" />
+    </template>
+    <template v-else>
+      <TodoItems
+        :todos="todoData.todoItems || []"
+        :isDisabled="todoData.isActionLoading"
+        @onToggleClick="events.onTodoToggleUpdate"
+        @onDeleteClick="events.onTodoDelete"
+        @onEditClick="events.onTodoEdit"
+      />
+    </template>
+  </div>
+</template>
 ```
 
-This illustrates how organisms in Atomic Design are composed of molecules and atoms to create larger and more complex components. The `Header` organism, in this case, represents a common structure that might appear at the top of many pages in our application.
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/organisms/TodoList/TodoList.component.js
+import { html } from "lit";
+import "../../atoms/Alert/app-alert";
+import "../../molecules/AddTodoForm/app-add-todo-form";
+import "../../molecules/TodoItems/app-todo-items";
+import "../../skeletons/Skeleton/app-skeleton";
+
+export default function TodoList({ todoData, events }) {
+  const { onTodoCreate, onTodoEdit, onTodoUpdate, onTodoToggleUpdate, onTodoDelete } = events;
+  return html`
+    ${todoData.error ? html`
+      <app-alert .variant=${"error"} .show=${!!todoData.error} .message=${todoData.error}></app-alert>
+    ` : null}
+    <app-add-todo-form
+      .todoValue=${todoData.currentTodoItem.text || ""}
+      @onTodoAdd=${onTodoCreate}
+      @onTodoUpdate=${onTodoUpdate}
+      .placeholder=${"Add your task"}
+      .isLoading=${todoData.isActionLoading}
+      .buttonInfo=${{
+        label: todoData.currentTodoItem.text ? "Save" : "Add",
+        variant: "primary",
+      }}
+    ></app-add-todo-form>
+    ${todoData.isContentLoading ? html`
+      <app-skeleton height="24px"></app-skeleton>
+      <app-skeleton height="24px"></app-skeleton>
+      <app-skeleton height="24px"></app-skeleton>
+    ` : html`
+      <app-todo-items
+        .todos=${todoData.todoItems || []}
+        .isDisabled=${todoData.isActionLoading}
+        @onToggleClick=${onTodoToggleUpdate}
+        @onDeleteClick=${onTodoDelete}
+        @onEditClick=${onTodoEdit}
+      ></app-todo-items>
+    `}
+  `;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+The organism's *interface* — `{ todoData, events }` — is identical in all four tabs. Containers in each template subscribe to their respective store (Redux store / NgRx selectors / Pinia store / saga-backed store) and fan the same prop shape into this component, so the organism itself is store-agnostic and framework-portable in its *shape*.
 
 ### Practical Example: Product Grid with State Management
 

--- a/docs/ui/props.md
+++ b/docs/ui/props.md
@@ -27,71 +27,130 @@ Props serve as the component's API, and like any API, should be designed with ca
 
 ## Code Examples
 
-### Basic Example: Simple Props Usage
+### Basic Example: Loader props across frameworks
 
-Fundamental props demonstration showing data flow:
+The Loader atom has three props: `size`, `width`, `color`. That's it — a pure, read-only, defaultable input surface. Here's the same atom in every `chota-*` template, showing how each framework declares props, applies defaults, and derives a value from them.
 
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// Button.js - Component receiving props
+// templates/chota-react-redux/src/ui/atoms/Loader/Loader.component.jsx
+// Props are plain destructured arguments. Defaults are applied inline
+// via ||. No PropTypes needed for a three-prop atom.
+import "./Loader.style.css";
 
-import React from 'react';
-
-const Button = ({ label, onClick, variant = 'primary', disabled = false }) => {
-  // Props are read-only - cannot modify them
-  // variant and disabled have default values
-  
+export default function Loader({ size, width, color }) {
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={`btn btn--${variant}`}
-    >
-      {label}
-    </button>
+    <span
+      className="loader"
+      style={{
+        height: size || "48px",
+        width: size || "48px",
+        border: `${width || "5px"} solid ${color || "#fff"}`,
+        borderBottomColor: "transparent",
+      }}
+    ></span>
   );
-};
+}
 
-export default Button;
+// <Loader size="24px" width="3px" color="#333" />
 ```
 
-Usage showing prop passing:
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Loader/Loader.component.ts
+// @Input() declares each prop. Defaults live next to the declaration.
+// A getter derives the inline style string at render time.
+import { Component, Input } from '@angular/core';
 
-```jsx
-// App.js - Parent component passing props
+@Component({
+  selector: 'app-loader',
+  standalone: true,
+  templateUrl: './Loader.component.html',
+  styleUrls: ['./Loader.style.css'],
+})
+export default class LoaderComponent {
+  @Input() size = '48px';
+  @Input() width = '5px';
+  @Input() color = '#fff';
 
-import React from 'react';
-import Button from './Button';
+  get styles() {
+    return `height:${this.size};width:${this.size};`
+         + `border:${this.width} solid ${this.color};`
+         + `border-bottom-color:transparent;`;
+  }
+}
 
-const App = () => {
-  const handleClick = () => {
-    console.log('Button clicked!');
-  };
-
-  return (
-    <div>
-      {/* Passing different props to same component */}
-      <Button 
-        label="Save" 
-        onClick={handleClick} 
-        variant="primary" 
-      />
-      
-      <Button 
-        label="Cancel" 
-        onClick={() => console.log('Cancelled')} 
-        variant="secondary" 
-      />
-      
-      <Button 
-        label="Delete" 
-        onClick={() => console.log('Deleted')} 
-        variant="danger"
-        disabled={true}
-      />
-    </div>
-  );
-};
+// Usage: <app-loader size="24px" width="3px" color="#333"></app-loader>
 ```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/atoms/Loader/Loader.component.vue -->
+<!-- Props live in the `props:` array (or an object with types/defaults).
+     A method on the component derives the style string. -->
+<template>
+  <span class="loader" :style="getLoaderStyle()"></span>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  props: ['size', 'width', 'color'],
+  methods: {
+    getLoaderStyle() {
+      return `
+        height: ${this.size || '48px'};
+        width: ${this.size || '48px'};
+        border: ${this.width || '5px'} solid ${this.color || '#fff'};
+        border-bottom-color: transparent;
+      `;
+    },
+  },
+});
+</script>
+
+<!-- Usage: <Loader size="24px" width="3px" color="#333" /> -->
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/atoms/Loader/Loader.component.js
+// The haunted function receives props as its first argument, the same as
+// a React function component. Lit-html template tagging builds the DOM.
+import { html } from "lit";
+import style from "./Loader.style.js";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+
+export default function Loader({ size, width, color }) {
+  useComputedStyles(this, [style]);
+  return html`
+    <span
+      class="loader"
+      style=${`
+        height: ${size || "48px"};
+        width: ${size || "48px"};
+        border: ${`${width || "5px"} solid ${color || "#fff"}`};
+        border-bottom-color: transparent;
+      `}
+    ></span>
+  `;
+}
+
+// Usage: <app-loader size="24px" width="3px" color="#333"></app-loader>
+// Complex values (objects, functions) must be passed as properties with `.`:
+//   <app-loader .size=${size} .color=${color}></app-loader>
+```
+
+{::nomarkdown}</div>{:/}
+
+Three takeaways the tabs make obvious:
+
+- **Where defaults live.** React puts them inline (`size || "48px"`). Angular puts them on the `@Input()` declaration. Vue's array form forces them into the method body; its object form would let you declare defaults on the prop. Haunted/WC uses the same inline-`||` pattern React does.
+- **How the DOM reads props.** React / Vue / haunted bind them directly. Angular separates template (`Loader.component.html`) from class — the getter is consumed by the template via `[style]="styles"`.
+- **HTML attributes vs JS properties in WC.** Strings work as attributes (`size="24px"`). Complex values (functions, objects) need the `.prop=${value}` form, or Lit will stringify them.
 
 ### Practical Example: Props with TypeScript and Validation
 

--- a/docs/ui/skeleton.md
+++ b/docs/ui/skeleton.md
@@ -67,98 +67,115 @@ By incorporating skeleton screens into frontend development, developers can crea
 
 ## Code Examples
 
-### Basic Example: Simple Card Skeleton
+### Basic Example: Skeleton atom across frameworks
 
+The Skeleton atom is the loading-state cousin of `<div>` — a sized box you put in a layout while data is in flight to reserve space and avoid CLS. Each `chota-*` template ships the same prop shape (`variant`, `height`, `width`, `style`) over a single `.skeleton` element.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```jsx
-// CardSkeleton.jsx - Basic skeleton component
-import React from 'react';
-import './CardSkeleton.css';
+// templates/chota-react-redux/src/ui/skeletons/Skeleton/Skeleton.component.jsx
+import "./Skeleton.style.css";
 
-const CardSkeleton = () => {
+export default function Skeleton({ variant, height, width, style }) {
   return (
-    <div className="card-skeleton">
-      <div className="card-skeleton__image"></div>
-      <div className="card-skeleton__content">
-        <div className="card-skeleton__title"></div>
-        <div className="card-skeleton__text"></div>
-        <div className="card-skeleton__text card-skeleton__text--short"></div>
-      </div>
-    </div>
+    <div
+      className={`skeleton skeleton-${variant ? variant : "text"}`}
+      style={{
+        ...style,
+        height,
+        width,
+      }}
+    ></div>
   );
-};
-
-export default CardSkeleton;
-```
-
-```css
-/* CardSkeleton.css */
-.card-skeleton {
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  overflow: hidden;
-  background: white;
-}
-
-.card-skeleton__image {
-  width: 100%;
-  height: 200px;
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-}
-
-.card-skeleton__content {
-  padding: 1rem;
-}
-
-.card-skeleton__title {
-  height: 24px;
-  background: #f0f0f0;
-  border-radius: 4px;
-  margin-bottom: 0.75rem;
-  width: 70%;
-}
-
-.card-skeleton__text {
-  height: 16px;
-  background: #f0f0f0;
-  border-radius: 4px;
-  margin-bottom: 0.5rem;
-}
-
-.card-skeleton__text--short {
-  width: 50%;
-}
-
-@keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
 }
 ```
 
-Usage:
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/skeletons/Skeleton/Skeleton.component.ts
+import { Component, Input } from '@angular/core';
 
-```jsx
-const ProductGrid = () => {
-  const { products, loading } = useProducts();
-  
-  if (loading) {
-    return (
-      <div className="product-grid">
-        {Array(6).fill(0).map((_, i) => (
-          <CardSkeleton key={i} />
-        ))}
-      </div>
-    );
+@Component({
+  selector: 'app-skeleton',
+  standalone: true,
+  templateUrl: './Skeleton.component.html',
+  styleUrls: ['./Skeleton.style.css'],
+})
+export default class SkeletonComponent {
+  @Input() width = "100%";
+  @Input() height = "1rem";
+  @Input() style = {};
+  @Input() variant = "text";
+
+  get classes() {
+    return `skeleton skeleton-${this.variant || "text"}`;
   }
-  
-  return (
-    <div className="product-grid">
-      {products.map(p => <ProductCard key={p.id} product={p} />)}
-    </div>
-  );
-};
+
+  get computedStyle() {
+    return `height: ${this.height}; width: ${this.width};`;
+  }
+}
 ```
+
+```html
+<!-- Skeleton.component.html -->
+<div [class]="classes" [style]="computedStyle"></div>
+```
+
+Vue
+```vue
+<!-- templates/chota-vue-pinia/src/ui/skeletons/Skeleton/Skeleton.component.vue -->
+<template>
+  <div :class="getSkeletonClass()" :style="getSkeletonStyle()"></div>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  props: ['variant', 'height', 'width', 'style'],
+  methods: {
+    getSkeletonClass() {
+      return `skeleton skeleton-${this.variant || "text"}`;
+    },
+    getSkeletonStyle() {
+      return `
+        height: ${this.height};
+        width: ${this.width};
+      `;
+    },
+  },
+})
+</script>
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/ui/skeletons/Skeleton/Skeleton.component.js
+import { html } from "lit";
+import styles from "./Skeleton.style";
+import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+
+export default function Skeleton({ variant, height, width, styleCSS }) {
+  useComputedStyles(this, [styles]);
+  return html`
+    <div
+      class=${`skeleton skeleton-${variant ? variant : "text"}`}
+      style=${`
+        ${styleCSS || ''}
+        height: ${height};
+        width: ${width};
+      `}
+    ></div>
+  `;
+}
+```
+
+{::nomarkdown}</div>{:/}
+
+The shape is intentionally tiny so the skeleton can be sprinkled freely. The four implementations differ only in style API: React passes a style *object*; Angular's getter and Vue's method both build a CSS *string* (because their templates take `[style]` / `:style` as a string when convenient); the WC version concatenates the same string and threads it into Lit's template literal. In all four, the rendered DOM ends up exactly the same: `<div class="skeleton skeleton-text" style="height:24px;width:100%">`.
 
 ### Practical Example: List Skeleton with Variants
 

--- a/docs/ui/story.md
+++ b/docs/ui/story.md
@@ -45,113 +45,145 @@ By leveraging stories, developers can efficiently build, document, and test UI c
 
 ## Code Examples
 
-### Basic Example: Button Component Stories
+### Basic Example: Button stories across Storybook flavours
 
+Storybook 10 standardises on Component Story Format (CSF 3) — one `default` export with `title` and `component`, plus named exports per story. The framework wrapper (`@storybook/react-vite` / `@storybook/angular` / `@storybook/vue3-vite` / `@storybook/web-components-vite`) decides how `args` get plugged into your component. Same Button, four CSF dialects.
+
+{::nomarkdown}<div class="code-tabs">{:/}
+
+React
 ```javascript
-// Button.stories.js - Basic story file structure
-import React from 'react';
-import { Button } from './Button';
+// templates/chota-react-redux/src/ui/atoms/Button/Button.stories.js
+// CSF 3 + react-vite. `args` map directly onto the component's props.
+import Button from "./Button.component";
 
-// Default export: Component metadata
-export default {
-  title: 'UI/Button',  // Sidebar location
-  component: Button,
-  // Automatic prop documentation
-  argTypes: {
-    variant: {
-      control: 'select',
-      options: ['primary', 'secondary', 'danger']
-    },
-    size: {
-      control: 'radio',
-      options: ['small', 'medium', 'large']
-    },
-    disabled: {
-      control: 'boolean'
-    },
-    onClick: { action: 'clicked' }  // Log clicks in Actions panel
-  }
+export default { title: "Atoms/Button", component: Button };
+
+export const Default = {
+  args: {
+    className: "button primary",
+    children: "Sample Button",
+  },
 };
 
-// Named exports: Individual stories
-
-// Story 1: Primary button (most common state)
-export const Primary = {
+export const Loading = {
   args: {
-    variant: 'primary',
-    size: 'medium',
-    children: 'Click me'
-  }
-};
-
-// Story 2: Secondary variant
-export const Secondary = {
-  args: {
-    variant: 'secondary',
-    size: 'medium',
-    children: 'Cancel'
-  }
-};
-
-// Story 3: Danger/destructive action
-export const Danger = {
-  args: {
-    variant: 'danger',
-    size: 'medium',
-    children: 'Delete'
-  }
-};
-
-// Story 4: Disabled state
-export const Disabled = {
-  args: {
-    variant: 'primary',
-    size: 'medium',
-    children: 'Click me',
-    disabled: true
-  }
-};
-
-// Story 5: Large button
-export const Large = {
-  args: {
-    variant: 'primary',
-    size: 'large',
-    children: 'Large Button'
-  }
-};
-
-// Story 6: Small button
-export const Small = {
-  args: {
-    variant: 'primary',
-    size: 'small',
-    children: 'Small'
-  }
-};
-
-// Story 7: Long text edge case
-export const LongText = {
-  args: {
-    variant: 'primary',
-    size: 'medium',
-    children: 'This is a button with very long text that might wrap or overflow'
-  }
-};
-
-// Story 8: Icon button
-export const WithIcon = {
-  args: {
-    variant: 'primary',
-    size: 'medium',
-    children: (
-      <>
-        <Icon name="search" /> Search
-      </>
-    )
-  }
+    isLoading: true,
+    className: "button primary",
+    children: "Sample Button",
+  },
 };
 ```
+
+Angular
+```ts
+// templates/chota-angular-ngrx/src/ui/atoms/Button/Button.stories.ts
+// Angular stories pair `args` with a small `render` function that maps
+// them into a component template (since args don't auto-bind onto Inputs).
+import type { Meta, StoryObj } from '@storybook/angular';
+import ButtonComponent from './Button.component';
+
+type Story = StoryObj<ButtonComponent>;
+
+export default {
+  title: 'Atoms/Button',
+  component: ButtonComponent,
+} satisfies Meta<ButtonComponent>;
+
+export const Default: Story = {
+  args: { classes: 'button primary', isLoading: false },
+  render: (args) => ({
+    props: args,
+    template: `<app-button [classes]="classes" [isLoading]="isLoading">Button</app-button>`,
+  }),
+};
+
+export const Loading: Story = {
+  args: { isLoading: true, classes: 'button primary' },
+  render: (args) => ({
+    props: args,
+    template: `<app-button [classes]="classes" [isLoading]="isLoading">Sample Button</app-button>`,
+  }),
+};
+```
+
+Vue
+```javascript
+// templates/chota-vue-pinia/src/ui/atoms/Button/Button.stories.js
+// Vue's CSF uses a Template factory that returns a component definition.
+// Each story binds args via `Template.bind({})` — the classic CSF 2 form,
+// still supported in Storybook 10 alongside CSF 3.
+import { defineComponent } from 'vue';
+import Button from "./Button.component.vue";
+
+const Template = (args) => defineComponent({
+  components: { Button },
+  setup: () => ({ args }),
+  template: '<Button @onClick="args.onClick" :class="args.class" :isLoading="args.isLoading">{{ args.label }}</Button>',
+});
+
+export default { title: "Atoms/Button", component: Button };
+
+export const Default = Template.bind({});
+Default.args = {
+  class: "button primary",
+  label: "Sample Button",
+  onClick: () => console.log('working on click'),
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  isLoading: true,
+  class: "button primary",
+  label: "Sample Button",
+};
+```
+
+Web Components
+```javascript
+// templates/chota-wc-saga/src/ui/atoms/Button/Button.stories.js
+// web-components-vite stories use Lit-html in the render function.
+// Note `.classes=` for property binding and `@onClick=` for the
+// CustomEvent emitted by the Button atom.
+import { html } from 'lit';
+import './app-button';
+
+export default {
+  title: 'Atoms/Button',
+  render: (args) => html`
+    <app-button .classes="${args.classes}" .isLoading="${args.isLoading}"
+                @onClick="${args.onClick}">
+      ${args.label}
+    </app-button>
+  `,
+};
+
+export const Default = {
+  args: {
+    classes: 'button primary',
+    label: 'Sample Button',
+    onClick: (e) => console.log('click', e.detail),
+  },
+};
+
+export const Loading = {
+  args: {
+    isLoading: true,
+    classes: 'button primary',
+    label: 'Sample Button',
+  },
+};
+```
+
+{::nomarkdown}</div>{:/}
+
+The CSF *meta-shape* (`default` export with `title`/`component` + named story exports with `args`) is identical across all four. Where they diverge:
+
+- **React + Web Components** can let `args` flow straight through to the component (React via prop spread, WC via Lit's render template referencing args by name).
+- **Angular** needs an explicit `render` function returning `{ props, template }` because Angular Inputs don't auto-bind from a generic prop bag.
+- **Vue** still uses the classic `Template.bind({})` factory pattern in the shipped templates, though CSF 3 with object args also works fine.
+
+Storybook addons (`addon-docs`, `addon-a11y`, `addon-controls`) all read these stories the same way regardless of framework.
 
 ### Practical Example: Form Component with Decorators and Play Functions
 

--- a/docs/ui/theme.md
+++ b/docs/ui/theme.md
@@ -88,102 +88,143 @@ By understanding these theming patterns, developers can choose the most suitable
 
 ## Code Examples
 
-### Basic Example: CSS Custom Properties for Theming
+### Basic Example: Theme provider across frameworks
 
-Fundamental theme implementation using CSS variables:
+Every `chota-*` template ships the same `ui/theme.css` (CSS custom properties on `:root` plus a `body.dark` override). What differs is *how each framework reads the active theme out of state and propagates it to children*. Here are the four flavours, all from the templates.
+
+The shared design tokens (same in every template):
 
 ```css
-/* theme.css - Define design tokens */
+/* templates/chota-*/src/ui/theme.css — identical across all templates */
 :root {
-  /* Color tokens */
-  --color-primary: #3b82f6;
-  --color-secondary: #8b5cf6;
-  --color-success: #10b981;
-  --color-danger: #ef4444;
-  --color-warning: #f59e0b;
-  
-  /* Neutral colors */
-  --color-bg: #ffffff;
-  --color-surface: #f3f4f6;
-  --color-text: #111827;
-  --color-text-muted: #6b7280;
-  
-  /* Spacing scale */
-  --space-xs: 0.25rem;
-  --space-sm: 0.5rem;
-  --space-md: 1rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2rem;
-  
-  /* Typography */
-  --font-sans: system-ui, -apple-system, sans-serif;
-  --font-mono: 'Monaco', 'Courier New', monospace;
-  --text-sm: 0.875rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-xl: 1.25rem;
-  
-  /* Shadows */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-  
-  /* Border radius */
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 1rem;
+  --bg-color: #ffffff;
+  --bg-secondary-color: #f3f3f6;
+  --color-primary: #3b48a6;
+  --color-darkGrey: #3f4144;
+  --color-error: #d43939;
+  --font-color: #333333;
+  /* ...etc */
 }
 
-/* Dark theme override */
-[data-theme="dark"] {
-  --color-bg: #111827;
-  --color-surface: #1f2937;
-  --color-text: #f9fafb;
-  --color-text-muted: #9ca3af;
+body.dark {
+  --bg-color: #000;
+  --bg-secondary-color: #131316;
+  --font-color: #f5f5f5;
 }
 ```
 
-Using theme tokens in components:
+Each template then provides a thin "theme context" so atoms can react to a theme change without each subscribing to the store directly:
 
-```css
-/* button.css */
-.btn {
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-md);
-  font-family: var(--font-sans);
-  font-size: var(--text-base);
-  box-shadow: var(--shadow-sm);
-  transition: all 0.2s;
-}
+{::nomarkdown}<div class="code-tabs">{:/}
 
-.btn--primary {
-  background: var(--color-primary);
-  color: white;
-}
+React
+```jsx
+// templates/chota-react-redux/src/utils/providers/AtomicProvider.jsx
+// React Context wraps the children and pulls `theme` out of the Redux
+// store via useSelector. Atoms call useAtomicContext() to read it.
+import React, { createContext, useContext } from "react";
+import { useSelector } from "react-redux";
 
-.btn--secondary {
-  background: var(--color-secondary);
-  color: white;
-}
+const atomicContext = createContext(null);
 
-.card {
-  background: var(--color-surface);
-  color: var(--color-text);
-  padding: var(--space-lg);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-md);
-}
+const AtomicProvider = ({ children, components, modules }) => {
+  const theme = useSelector((state) => state.config.theme);
+  return (
+    <atomicContext.Provider value={{ components, modules, children, theme }}>
+      {children}
+    </atomicContext.Provider>
+  );
+};
+
+export const useAtomicContext = () => {
+  const ctx = useContext(atomicContext);
+  return ctx || { theme: '', components: {}, modules: {} };
+};
+
+export default AtomicProvider;
 ```
 
-```html
-<body data-theme="light">
-  <button class="btn btn--primary">Primary Button</button>
-  <div class="card">
-    <h3>Card Title</h3>
-    <p>Content uses theme colors</p>
-  </div>
-</body>
+Angular
+```ts
+// templates/chota-angular-ngrx/src/app/utils/providers/AtomicService.ts
+// Angular wraps the same idea in an Injectable service. Components inject
+// it and subscribe to theme$ via the async pipe in templates.
+import { Injectable, Optional } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable, of } from 'rxjs';
+import { AppState } from '../../state/index';
+import { getTheme } from '../../state/config/config.selectors';
+
+@Injectable({ providedIn: 'root' })
+export class AtomicService {
+  theme$: Observable<string>;
+
+  constructor(@Optional() private store: Store<AppState>) {
+    this.theme$ = this.store ? this.store.select(getTheme) : of('light');
+  }
+}
+
+// Component usage:
+// constructor(public atomic: AtomicService) {}
+// <body [class.dark]="(atomic.theme$ | async) === 'dark'">
 ```
+
+Vue
+```ts
+// templates/chota-vue-pinia/src/main.ts
+// Vue exposes the theme as a global property on the app via
+// app.config.globalProperties, backed by a reactive object.
+// Components read it via this.$theme (Options API) or inject().
+import { createApp, reactive } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import './ui/theme.css'
+
+const themeState = reactive({ theme: '' })
+
+const app = createApp(App)
+
+Object.defineProperty(app.config.globalProperties, '$theme', {
+  get() { return themeState.theme },
+  set(value: string) { themeState.theme = value },
+})
+
+app.use(createPinia()).mount('#app')
+```
+
+Web Components
+```js
+// templates/chota-wc-saga/src/utils/theme/hooks/useComputedStyles.js
+// The WC template adopts theme tokens via Constructable Stylesheets:
+// each component calls useComputedStyles(this, [style]) which adopts
+// the shared sheet onto its shadow root (or document) so :root tokens
+// resolve correctly inside encapsulated components.
+import { useConstructableStylesheets } from "./useConstructableStylesheets";
+
+export default function useComputedStyles(scope, styles, isGlobalAdoptedStyleSheetEnabled = true) {
+  useConstructableStylesheets(scope, styles, isGlobalAdoptedStyleSheetEnabled);
+}
+
+// In every WC atom:
+// import style from './Button.style';
+// import useComputedStyles from "../../../utils/theme/hooks/useComputedStyles";
+//
+// export default function Button(props) {
+//   useComputedStyles(this, [style]);
+//   // ...
+// }
+```
+
+{::nomarkdown}</div>{:/}
+
+The CSS tokens are intentionally framework-agnostic — all four templates share the exact same `theme.css` because that's the whole point of CSS custom properties. The differences are purely about *how the active theme name reaches the components*:
+
+- **React** — Context backed by a Redux selector, read via a hook.
+- **Angular** — Injectable service backed by an NgRx selector, read via the async pipe.
+- **Vue** — global property on the app instance, backed by a Pinia/reactive store, read via `this.$theme`.
+- **Web Components** — no provider at all for the theme value (which lives on `body`); instead a hook adopts shared stylesheets so tokens work inside shadow DOM.
+
+Switch the framework, the contract on the *DOM* (a class on `<body>` plus `:root` custom properties) stays the same.
 
 ### Practical Example: Dark Mode Toggle with JavaScript
 


### PR DESCRIPTION
## Summary

Fifth batch of cross-framework code tabs. Stacks on #33, #34, #35, #36.

| Doc | Frameworks shown |
|---|---|
| `ui/attributes.md` | Input atom across React · Angular · Vue · Web Components — highlights the property-vs-attribute distinction (most visible for `value` / `checked` / `disabled`), boolean-attribute footguns, and how each binding syntax (`prop=` JSX / `[prop]=` Angular / `:prop` Vue / `.prop=${}` Lit) ultimately resolves to `setAttribute` or property assignment under the hood |
| `ui/theme.md` | Theme provider across React (Context + `useSelector`) · Angular (Injectable service + `Store.select`) · Vue (`app.config.globalProperties.$theme` over `reactive()`) · Web Components (Constructable Stylesheets adopted via `useComputedStyles` hook). Shared `theme.css` with `:root` custom properties is identical in every template — only the conduit for "which theme is active right now?" varies |

Each tab group closes with a comparative callout drawing out where the patterns diverge.

Running total across #33, #34, #35, #36, #37:

- **UI**: atom, molecule, organism, component, props, events, skeleton, story, attributes, theme
- **State**: actions, reducer, store, selectors, middleware
- **Server**: container

Remaining candidates: `accessibility.md`, `state/operations.md` (currently small), `state/ajax.md`, `state/crud.md`.

## Test plan
- [ ] Tabs render and switch correctly on the deployed site
- [ ] Snippets match current template source

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG)_