### PR TITLE
Docs: stop Liquid eating Vue/JSX/Angular code samples (wrap fenced blocks in {% raw %})

### DIFF
--- a/docs/server/app-shell.md
+++ b/docs/server/app-shell.md
@@ -475,6 +475,7 @@ new AppShell();
 
 ### Example 2: App Shell with SSR and Hydration (Next.js)
 
+{% raw %}
 ```javascript
 // pages/_app.js (App Shell wrapper)
 import { AuthProvider } from '../contexts/AuthContext';
@@ -596,9 +597,11 @@ export async function getServerSideProps() {
   return { props: { data } };
 }
 ```
+{% endraw %}
 
 ### Example 3: Micro-Frontend Integration in App Shell
 
+{% raw %}
 ```javascript
 // app-shell/src/Shell.js
 import React, { Suspense, lazy } from 'react';
@@ -745,6 +748,7 @@ module.exports = {
   ]
 };
 ```
+{% endraw %}
 
 ## Common Mistakes
 

--- a/docs/server/authentication.md
+++ b/docs/server/authentication.md
@@ -78,6 +78,7 @@ Authentication is the process of **verifying user identity** before granting acc
 
 ### Basic Example: Login Flow with JWT
 
+{% raw %}
 ```javascript
 // ===== AUTH CONTEXT + LOGIN =====
 // AuthContext.js - Global authentication state
@@ -318,6 +319,7 @@ function App() {
 
 export default App;
 ```
+{% endraw %}
 
 ### Practical Example: Axios Interceptors with Token Refresh
 

--- a/docs/server/localization.md
+++ b/docs/server/localization.md
@@ -36,6 +36,7 @@ SEO considerations for multilingual sites: **Separate URLs** per language (Googl
 
 Simple internationalization with react-i18next:
 
+{% raw %}
 ```javascript
 // ===== i18n.js - Configuration =====
 import i18n from 'i18next';
@@ -169,11 +170,13 @@ function ProductCard({ price, releaseDate }) {
   );
 }
 ```
+{% endraw %}
 
 ### Practical Example: Next.js with Dynamic Locale Routes
 
 Internationalized routing with SSR:
 
+{% raw %}
 ```javascript
 // ===== next.config.js =====
 module.exports = {
@@ -353,11 +356,13 @@ class MyDocument extends Document {
 
 export default MyDocument;
 ```
+{% endraw %}
 
 ### Advanced Example: RTL Support and Lazy Loading
 
 Dynamic bundle loading with RTL layout:
 
+{% raw %}
 ```javascript
 // ===== i18n.js - Lazy loading configuration =====
 import i18n from 'i18next';
@@ -414,6 +419,7 @@ function AppContent() {
 
 // ===== styles/globals.css - RTL-compatible styles =====
 ```
+{% endraw %}
 
 ```css
 /* Use logical properties for automatic RTL support */
@@ -595,6 +601,7 @@ function ItemCount({ count }) {
 // Breaks in Russian (1, 2-4, 5+ forms), Arabic (6 forms), Japanese (no plurals)
 ```
 
+{% raw %}
 ```javascript
 // ✅ GOOD: i18n library handles plural rules
 // en.json
@@ -617,6 +624,7 @@ function ItemCount({ count }) {
 }
 // Library automatically selects correct plural form per language
 ```
+{% endraw %}
 
 **Why it matters:** Each language has different pluralization rules—i18n libraries handle complexity automatically using CLDR data.
 

--- a/docs/server/mfe.md
+++ b/docs/server/mfe.md
@@ -376,6 +376,7 @@ export default function ProductList() {
 
 ### Example 2: Web Components with Framework-Agnostic Integration
 
+{% raw %}
 ```javascript
 // Checkout MFE: Built with React, exported as Web Component
 // checkout-mfe/src/CheckoutComponent.js
@@ -524,6 +525,7 @@ export default {
 </body>
 </html>
 ```
+{% endraw %}
 
 ### Example 3: Advanced Module Federation with Shared State and Authentication
 

--- a/docs/ui/atomic-design.md
+++ b/docs/ui/atomic-design.md
@@ -441,6 +441,7 @@ function Homepage() {
 
 ### Advanced Example: Atomic Design in Vue with Composition API
 
+{% raw %}
 ```vue
 <!-- ===== ATOMS ===== -->
 
@@ -725,6 +726,7 @@ function addToCart(product) {
 }
 </script>
 ```
+{% endraw %}
 
 ## Common Mistakes
 

--- a/docs/ui/attributes.md
+++ b/docs/ui/attributes.md
@@ -90,6 +90,7 @@ export default class InputComponent {
 }
 ```
 
+{% raw %}
 ```html
 <!-- Input.component.html -->
 <label [for]="id" class="sr-only">{{ name || 'Some Label' }}</label>
@@ -103,6 +104,7 @@ export default class InputComponent {
   (input)="onInputHandler($event)"
 />
 ```
+{% endraw %}
 
 Vue
 ```vue

--- a/docs/ui/component.md
+++ b/docs/ui/component.md
@@ -108,6 +108,7 @@ export default class AlertComponent implements OnChanges {
 ```
 
 Vue
+{% raw %}
 ```vue
 <!-- templates/chota-vue-pinia/src/ui/atoms/Alert/Alert.component.vue -->
 <template>
@@ -148,6 +149,7 @@ export default defineComponent({
 });
 </script>
 ```
+{% endraw %}
 
 Web Components
 ```js
@@ -474,6 +476,7 @@ export default {
 
 Usage:
 
+{% raw %}
 ```vue
 <!-- ProductCard.vue -->
 <template>
@@ -492,6 +495,7 @@ Usage:
   </Card>
 </template>
 ```
+{% endraw %}
 
 ## Common Mistakes
 

--- a/docs/ui/molecule.md
+++ b/docs/ui/molecule.md
@@ -111,6 +111,7 @@ export default class AddTodoFormComponent implements OnChanges {
 }
 ```
 
+{% raw %}
 ```html
 <!-- AddTodoForm.component.html -->
 <form (submit)="onSubmit($event)" class="add-todo-form">
@@ -123,8 +124,10 @@ export default class AddTodoFormComponent implements OnChanges {
   </div>
 </form>
 ```
+{% endraw %}
 
 Vue
+{% raw %}
 ```vue
 <!-- templates/chota-vue-pinia/src/ui/molecules/AddTodoForm/AddTodoForm.component.vue -->
 <template>
@@ -173,6 +176,7 @@ export default defineComponent({
 })
 </script>
 ```
+{% endraw %}
 
 Web Components
 ```js

--- a/docs/ui/organism.md
+++ b/docs/ui/organism.md
@@ -37,6 +37,7 @@ A real organism pulled from the `chota-*` templates: `TodoList` assembles an `Al
 {::nomarkdown}<div class="code-tabs">{:/}
 
 React
+{% raw %}
 ```jsx
 // templates/chota-react-redux/src/ui/organisms/TodoList/TodoList.component.jsx
 import Alert from "../../atoms/Alert/Alert.component";
@@ -81,6 +82,7 @@ export default function TodoList({ todoData, events }) {
   );
 }
 ```
+{% endraw %}
 
 Angular
 ```ts
@@ -171,6 +173,7 @@ Vue
 ```
 
 Web Components
+{% raw %}
 ```js
 // templates/chota-wc-saga/src/ui/organisms/TodoList/TodoList.component.js
 import { html } from "lit";
@@ -212,6 +215,7 @@ export default function TodoList({ todoData, events }) {
   `;
 }
 ```
+{% endraw %}
 
 {::nomarkdown}</div>{:/}
 

--- a/docs/ui/props.md
+++ b/docs/ui/props.md
@@ -34,6 +34,7 @@ The Loader atom has three props: `size`, `width`, `color`. That's it — a pure,
 {::nomarkdown}<div class="code-tabs">{:/}
 
 React
+{% raw %}
 ```jsx
 // templates/chota-react-redux/src/ui/atoms/Loader/Loader.component.jsx
 // Props are plain destructured arguments. Defaults are applied inline
@@ -56,6 +57,7 @@ export default function Loader({ size, width, color }) {
 
 // <Loader size="24px" width="3px" color="#333" />
 ```
+{% endraw %}
 
 Angular
 ```ts

--- a/docs/ui/skeleton.md
+++ b/docs/ui/skeleton.md
@@ -74,6 +74,7 @@ The Skeleton atom is the loading-state cousin of `<div>` — a sized box you put
 {::nomarkdown}<div class="code-tabs">{:/}
 
 React
+{% raw %}
 ```jsx
 // templates/chota-react-redux/src/ui/skeletons/Skeleton/Skeleton.component.jsx
 import "./Skeleton.style.css";
@@ -91,6 +92,7 @@ export default function Skeleton({ variant, height, width, style }) {
   );
 }
 ```
+{% endraw %}
 
 Angular
 ```ts

--- a/docs/ui/story.md
+++ b/docs/ui/story.md
@@ -108,6 +108,7 @@ export const Loading: Story = {
 ```
 
 Vue
+{% raw %}
 ```javascript
 // templates/chota-vue-pinia/src/ui/atoms/Button/Button.stories.js
 // Vue's CSF uses a Template factory that returns a component definition.
@@ -138,6 +139,7 @@ Loading.args = {
   label: "Sample Button",
 };
 ```
+{% endraw %}
 
 Web Components
 ```javascript

--- a/docs/ui/theme.md
+++ b/docs/ui/theme.md
@@ -118,6 +118,7 @@ Each template then provides a thin "theme context" so atoms can react to a theme
 {::nomarkdown}<div class="code-tabs">{:/}
 
 React
+{% raw %}
 ```jsx
 // templates/chota-react-redux/src/utils/providers/AtomicProvider.jsx
 // React Context wraps the children and pulls `theme` out of the Redux
@@ -143,6 +144,7 @@ export const useAtomicContext = () => {
 
 export default AtomicProvider;
 ```
+{% endraw %}
 
 Angular
 ```ts


### PR DESCRIPTION
## Summary

The site code samples were being silently mangled because Jekyll runs Liquid **before** kramdown, so `{{ ... }}` and `{% ... %}` *inside fenced code blocks* were being interpreted as Liquid expressions instead of left literal. The build still succeeded (Liquid renders unknown variables to empty string), so CI was green — but the rendered HTML showed broken Vue interpolation, broken JSX `style={{ ... }}` props, and broken Angular template bindings.

### Examples that were silently broken

| File | Line | Mangled by Liquid |
|---|---|---|
| `ui/molecule.md` | 121 | `{{ buttonInfo.label }}` (Angular template) |
| `ui/molecule.md` | 137 | `{{ label }}` (Vue interpolation) |
| `ui/story.md` | 122 | `{{ args.label }}` (Vue Storybook template) |
| `ui/story.md` | 204+ | `style={{ maxWidth: '400px' }}` (JSX) |
| `ui/attributes.md` | 95 | `{{ name &#124;&#124; 'Some Label' }}` (Angular) |

…and similar across `ui/{atomic-design, component, organism, props, skeleton, theme}.md`, `server/{app-shell, authentication, localization, mfe}.md`.

### Fix

Walk every doc, find every fenced code block, wrap any block containing `{{` or `{%` (and not already inside a `{% raw %}` region) with `{% raw %}` ... `{% endraw %}`. The `{% include quiz.html %}` calls live outside fenced blocks and are deliberately left as live Liquid.

**13 files, 40 lines added — only the wrap markers, no prose or structural changes.**

### Note: 503 on the custom domain

The site at `elegantfrontend.training` was returning **HTTP 503** when this was filed (the `grvpanchal.github.io/elegant` URL also redirects there and returns 503). The recent build + deploy CI runs both succeeded, so the 503 looks like a DNS / Pages-config / TLS-cert issue rather than a Jekyll problem. Worth checking:
- The DNS `A` records for `elegantfrontend.training` apex point at GitHub's current Pages IPs (185.199.108.153, 185.199.109.153, 185.199.110.153, 185.199.111.153)
- The "Enforce HTTPS" toggle in *Settings → Pages* — it sometimes needs to be re-enabled after a domain change
- The `CNAME` file in `docs/` matches the custom domain entered in Pages settings (it does — `elegantfrontend.training`)

This PR fixes the Jekyll-side issues. The 503 is separate and likely needs a touch in Pages settings / DNS.

## Test plan
- [ ] CI build + deploy both succeed
- [ ] After deploy, spot-check the rendered Vue tab in `ui/molecule.md`: `{{ label }}` should appear *as-is* in the code block, not as empty space
- [ ] Confirm `elegantfrontend.training` resolves and returns 200

https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeLxCK73tRxL911d5YQdiG)_