### PR TITLE
docs: add skills README catalogue and skills badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elegant
 
-[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-35-3F51B5)](./skills/README.md)
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant)
 
 Elegant is a command line tool to build an Elegant Front end Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elegant
 
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-35-3F51B5)](./skills/README.md)
+
 Elegant is a command line tool to build an Elegant Front end Architecture
 
 ## Cloning Boilerplates
@@ -53,5 +55,12 @@ To start working to build component with atomic design approach
 ```sh
 npm run storybook
 ```
+
+## Agent Skills
+
+This repo ships 35 [Agent Skills](https://agentskills.io) under [`skills/`](./skills/README.md)
+that document the architecture every template implements — atomic-design UI
+layers, state-management patterns, and server/routing concerns. See the
+[skills README](./skills/README.md) for the full catalogue.
 
 ### Happy Coding!!!

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # Elegant Agent Skills
 
-![Agent Skills](https://img.shields.io/badge/Agent%20Skills-35-3F51B5)
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant)
 ![Standard](https://img.shields.io/badge/standard-agentskills.io-blue)
 
 This folder contains the **Agent Skills** that document the architecture every

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,89 @@
+# Elegant Agent Skills
+
+![Agent Skills](https://img.shields.io/badge/Agent%20Skills-35-3F51B5)
+![Standard](https://img.shields.io/badge/standard-agentskills.io-blue)
+
+This folder contains the **Agent Skills** that document the architecture every
+[`elegant`](../README.md) template implements. Each skill is a self-contained
+folder with a `SKILL.md` written to the [Agent Skills open standard](https://agentskills.io) —
+prose design guidance an AI agent (or a human) can load when authoring or
+reviewing code in that area.
+
+Skills can be published to [skills.sh](https://skills.sh) or dropped into
+`~/.claude/skills/` to give an agent durable, on-demand knowledge of the
+elegant front-end architecture.
+
+## How a skill is structured
+
+```
+skills/<skill-name>/
+└── SKILL.md      # YAML frontmatter (name, description, when_to_use, paths) + prose guidance
+```
+
+The frontmatter's `paths` globs let an agent auto-surface the right skill based
+on the file being edited (e.g. `ui-atom` activates under `**/ui/atoms/**`).
+
+## Skills
+
+The 35 skills are grouped into three layers that mirror the template source
+layout (`src/ui`, `src/state`, and the server/routing concerns).
+
+### UI — `src/ui/{atoms,molecules,organisms,templates,skeletons}` and primitives
+
+| Skill | What it covers |
+| --- | --- |
+| [`ui-atomic-design`](./ui-atomic-design/SKILL.md) | The five-level component hierarchy (Atoms → Molecules → Organisms → Templates → Pages) as a shared vocabulary and folder convention. |
+| [`ui-atom`](./ui-atom/SKILL.md) | Atoms — the smallest single-purpose building blocks (buttons, inputs, icons, labels). |
+| [`ui-molecule`](./ui-molecule/SKILL.md) | Molecules — functional groups of atoms (SearchBar, FormField) with one cohesive purpose. |
+| [`ui-organism`](./ui-organism/SKILL.md) | Organisms — complex feature-level sections that compose molecules and connect to state. |
+| [`ui-template`](./ui-template/SKILL.md) | Templates — page-level wireframes arranging organisms into layout slots, no data fetching. |
+| [`ui-skeleton`](./ui-skeleton/SKILL.md) | Skeleton loading placeholders that mirror final content and prevent layout shift. |
+| [`ui-component`](./ui-component/SKILL.md) | General component design — encapsulation, single-responsibility, props-in/events-out. |
+| [`ui-element`](./ui-element/SKILL.md) | Component vs Element vs DOM node, and custom-element registration. |
+| [`ui-dom`](./ui-dom/SKILL.md) | DOM manipulation essentials — querySelector, textContent vs innerHTML, fragment batching. |
+| [`ui-events`](./ui-events/SKILL.md) | DOM event handling — capture/bubble, delegation, preventDefault vs stopPropagation, cleanup. |
+| [`ui-attributes`](./ui-attributes/SKILL.md) | HTML attribute semantics — boolean attributes, attribute-vs-property, `data-*`, ARIA. |
+| [`ui-props`](./ui-props/SKILL.md) | Component props design — read-only data, unidirectional flow, typed interfaces, defaults. |
+| [`ui-accessibility`](./ui-accessibility/SKILL.md) | Web accessibility — semantic HTML, ARIA, keyboard nav, focus management, WCAG POUR. |
+| [`ui-theme`](./ui-theme/SKILL.md) | Design-token systems — semantic CSS custom properties and light/dark theming. |
+| [`ui-story`](./ui-story/SKILL.md) | Storybook story authoring — CSF, argTypes, play functions, edge-state coverage. |
+
+### State — `src/state` (Redux / RTK / NgRx / Pinia)
+
+| Skill | What it covers |
+| --- | --- |
+| [`state-state`](./state-state/SKILL.md) | State-management fundamentals — local vs lifted vs global vs server vs URL state. |
+| [`state-store`](./state-store/SKILL.md) | Redux store architecture — configureStore, slices, normalised shape, typed hooks. |
+| [`state-actions`](./state-actions/SKILL.md) | Action design — FSA-compliant events, request/success/failure patterns. |
+| [`state-reducer`](./state-reducer/SKILL.md) | Reducer design — pure functions, immutable updates, combineReducers composition. |
+| [`state-selectors`](./state-selectors/SKILL.md) | Selectors — Reselect memoisation, composition, parameterised factories. |
+| [`state-middleware`](./state-middleware/SKILL.md) | Redux middleware — the `store => next => action` pipeline for side effects and async. |
+| [`state-operations`](./state-operations/SKILL.md) | Async operations — status tracking, optimistic updates, race-condition handling. |
+| [`state-ajax`](./state-ajax/SKILL.md) | Async data-fetching — Fetch vs Axios, cancellation, createAsyncThunk integration. |
+| [`state-crud`](./state-crud/SKILL.md) | CRUD slice patterns — consistent action naming and normalised `{ byId, allIds }` shapes. |
+
+### Server — routing, rendering, and deployment concerns
+
+| Skill | What it covers |
+| --- | --- |
+| [`server-page`](./server-page/SKILL.md) | Page components — the thin data-fetching layer binding a route to a template. |
+| [`server-container`](./server-container/SKILL.md) | Container/presentational split — smart containers vs dumb presentational children. |
+| [`server-router`](./server-router/SKILL.md) | Client-side routing — route tables, dynamic segments, guards, lazy chunks, scroll/focus. |
+| [`server-ssr`](./server-ssr/SKILL.md) | Server-Side Rendering — HTML generation, hydration, prefetching, mismatch debugging. |
+| [`server-ssg`](./server-ssg/SKILL.md) | Static Site Generation — build-time pre-rendering, getStaticPaths, ISR revalidation. |
+| [`server-app-shell`](./server-app-shell/SKILL.md) | App Shell architecture — cached skeleton served via Service Worker, offline fallbacks. |
+| [`server-api`](./server-api/SKILL.md) | API service-layer — client with interceptors, domain services, token refresh, cancellation. |
+| [`server-authentication`](./server-authentication/SKILL.md) | Authentication — JWT access+refresh flows, secure storage, route guards. |
+| [`server-proxy`](./server-proxy/SKILL.md) | Proxy configuration — dev-server proxies for CORS and production reverse proxies. |
+| [`server-protocol`](./server-protocol/SKILL.md) | HTTPS/TLS guidance — mandatory HTTPS, HSTS, certs, security headers. |
+| [`server-mfe`](./server-mfe/SKILL.md) | Micro-frontend architecture — independently deployable modules, shared runtimes, event bus. |
+
+## Using these skills
+
+- **With Claude Code / agents:** copy a skill folder into `~/.claude/skills/`,
+  or reference it from a project. The agent loads the `SKILL.md` when its
+  `paths` match the file you're editing.
+- **Publish:** push to [skills.sh](https://skills.sh) following the
+  [Agent Skills standard](https://agentskills.io).
+- **Read as docs:** every `SKILL.md` is plain Markdown — open it directly to
+  learn the pattern it documents.

--- a/skills/server-api/README.md
+++ b/skills/server-api/README.md
@@ -1,0 +1,34 @@
+# Server API
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-api)
+
+> `server-api` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+API service-layer patterns — axios/fetch client with interceptors, domain-scoped service objects (UserService, ProductService), auth-token refresh, request cancellation, and error normalisation. Use when adding or reviewing HTTP call sites, organising services under api/ or services/, or centralising cross-cutting request concerns.
+
+## When to use
+
+Creating or refactoring API clients and service modules; adding auth-refresh or error interceptors; replacing scattered fetch/axios calls with a typed service layer; wiring AbortController cancellation.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-api
+```
+
+Or copy the [`server-api/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/api/**/*.{js,ts}`
+- `**/services/**/*.{js,ts}`
+- `**/*Service*.{js,ts}`
+- `**/*Api*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-app-shell/README.md
+++ b/skills/server-app-shell/README.md
@@ -1,0 +1,33 @@
+# Server App Shell
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-app-shell)
+
+> `server-app-shell` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+App Shell architecture — the cached HTML/CSS/JS skeleton (header, nav, footer) served instantly via Service Worker while dynamic content streams in. Use when building PWAs, wiring service-worker caches, inlining critical CSS, or adding offline fallbacks and skeleton loading states.
+
+## When to use
+
+Designing the root layout and service-worker cache strategy for a PWA; separating static shell from dynamic content; adding offline fallback pages; optimising first-paint with inlined critical CSS.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-app-shell
+```
+
+Or copy the [`server-app-shell/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/shell/**/*.{jsx,tsx,js,ts}`
+- `**/layout/**/*.{jsx,tsx}`
+- `**/app/**/*.{jsx,tsx}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-authentication/README.md
+++ b/skills/server-authentication/README.md
@@ -1,0 +1,33 @@
+# Server Authentication
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-authentication)
+
+> `server-authentication` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Authentication patterns — JWT access+refresh token flows, httpOnly-cookie storage, axios refresh interceptors, auth context providers, and protected-route guards. Use when building login/logout, handling 401 retry loops, choosing secure token storage, or guarding routes that require a session.
+
+## When to use
+
+Implementing login/logout and session bootstrap; wiring access/refresh-token refresh in API interceptors; deciding between memory, cookie, and localStorage token storage; protecting routes behind auth guards.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-authentication
+```
+
+Or copy the [`server-authentication/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/auth/**/*.{js,ts}`
+- `**/*auth*.{js,ts}`
+- `**/login/**/*.{jsx,tsx}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-container/README.md
+++ b/skills/server-container/README.md
@@ -1,0 +1,32 @@
+# Server Container
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-container)
+
+> `server-container` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Container/presentational component split — "smart" containers connect to the store, fetch data, and orchestrate loading/error/empty states; "dumb" children just render props. Use when extracting data logic from views, introducing custom hooks, or reviewing `*Container` components.
+
+## When to use
+
+Splitting a component into container + presentational pair; connecting a view to Redux/NgRx/Pinia; extracting reusable data logic into a custom hook; reviewing whether a presentational component accidentally imports store code.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-container
+```
+
+Or copy the [`server-container/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/containers/**/*.{jsx,tsx,vue}`
+- `**/*Container*.{jsx,tsx,vue}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-mfe/README.md
+++ b/skills/server-mfe/README.md
@@ -1,0 +1,33 @@
+# Server MFE
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-mfe)
+
+> `server-mfe` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Micro-frontend architecture — independently deployable UI modules stitched together via Module Federation, import maps, or web components, with shared runtimes, versioned contracts, and an event-bus for cross-MFE comms. Use when splitting a monolith UI by team/domain, configuring a shell+remotes topology, or budgeting bundle size per MFE.
+
+## When to use
+
+Splitting a UI by bounded context or team ownership; configuring Module Federation shared deps and remotes; choosing between MFE integration strategies (Module Fed vs web components vs iframes vs import maps); designing cross-MFE event communication.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-mfe
+```
+
+Or copy the [`server-mfe/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/mfe/**/*.{jsx,tsx,js,ts}`
+- `**/remote/**/*.{js,ts}`
+- `**/shell/**/*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-page/README.md
+++ b/skills/server-page/README.md
@@ -1,0 +1,32 @@
+# Server Page
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-page)
+
+> `server-page` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Page components — the thin data-fetching layer that binds a route to a template, invoking getServerSideProps/getStaticProps and passing props down. Use when creating a new route, choosing SSR vs SSG vs ISR for a page, or reviewing whether a page is doing template-level work it shouldn't.
+
+## When to use
+
+Adding a new route/page file; deciding between getServerSideProps, getStaticProps, and ISR; wiring SEO head tags; keeping pages thin and templates dumb.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-page
+```
+
+Or copy the [`server-page/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/pages/**/*.{jsx,tsx,vue}`
+- `**/app/**/*.{jsx,tsx}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-protocol/README.md
+++ b/skills/server-protocol/README.md
@@ -1,0 +1,33 @@
+# Server Protocol
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-protocol)
+
+> `server-protocol` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+HTTPS/TLS protocol guidance — mandatory HTTPS, HSTS headers, cert management (Let's Encrypt, mkcert for dev), security headers (CSP, X-Frame-Options), and HTTP→HTTPS redirects. Use when hardening a deployment, fixing mixed-content warnings, or setting up trusted local-dev certificates.
+
+## When to use
+
+Setting up HTTPS in production or local dev (mkcert, Vite https); configuring HSTS and security headers; choosing a cert type (DV/OV/EV) or automating renewal; eliminating mixed-content warnings.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-protocol
+```
+
+Or copy the [`server-protocol/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/server/**/*.{js,ts}`
+- `**/*ssl*.{js,ts}`
+- `**/*https*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-proxy/README.md
+++ b/skills/server-proxy/README.md
@@ -1,0 +1,33 @@
+# Server Proxy
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-proxy)
+
+> `server-proxy` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Proxy configuration — dev-server proxies (Vite, webpack, CRA setupProxy) to dodge CORS, plus production reverse proxies (Nginx, Cloudflare) for SSL termination, load balancing, and WebSocket forwarding. Use when wiring /api forwarding in local dev, debugging CORS, or writing Nginx configs for deployment.
+
+## When to use
+
+Configuring Vite/webpack/CRA dev proxies to avoid CORS; writing Nginx/Cloudflare reverse-proxy rules; forwarding WebSocket upgrades; separating dev-time vs production proxy strategies.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-proxy
+```
+
+Or copy the [`server-proxy/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/proxy/**/*.{js,ts}`
+- `**/vite.config*.{js,ts}`
+- `**/webpack.config*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-router/README.md
+++ b/skills/server-router/README.md
@@ -1,0 +1,33 @@
+# Server Router
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-router)
+
+> `server-router` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Client-side routing patterns — declarative route tables, dynamic segments, protected routes, lazy-loaded chunks, scroll restoration, and accessible focus management on navigation. Use when wiring React Router/Vue Router/Angular Router, adding an auth guard, or fixing missing 404/scroll-to-top behaviour.
+
+## When to use
+
+Setting up or restructuring the route table; extracting params with useParams/useNavigate; adding ProtectedRoute/auth guards; lazy-loading route components; fixing scroll restoration or accessibility announcements on navigation.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-router
+```
+
+Or copy the [`server-router/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/routes/**/*.{jsx,tsx,js,ts}`
+- `**/*Router*.{jsx,tsx}`
+- `**/*routes*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-ssg/README.md
+++ b/skills/server-ssg/README.md
@@ -1,0 +1,32 @@
+# Server SSG
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-ssg)
+
+> `server-ssg` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Static Site Generation — build-time HTML pre-rendering, getStaticProps/getStaticPaths, ISR revalidate intervals, and fallback strategies (false/true/blocking). Use when choosing SSG vs SSR for a route, tuning ISR revalidation, or handling dynamic-route pre-rendering for blogs, docs, and marketing pages.
+
+## When to use
+
+Deciding SSG vs SSR vs CSR for a given page; setting up getStaticProps/getStaticPaths; picking a fallback strategy for dynamic routes; configuring ISR revalidate windows for semi-static content.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-ssg
+```
+
+Or copy the [`server-ssg/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/pages/**/*.{jsx,tsx,vue,md,mdx}`
+- `**/*static*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/server-ssr/README.md
+++ b/skills/server-ssr/README.md
@@ -1,0 +1,33 @@
+# Server SSR
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/server-ssr)
+
+> `server-ssr` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Server-Side Rendering (SSR) patterns — initial HTML generation, client hydration, data prefetching via getServerSideProps/renderToString, and hydration-mismatch debugging. Use when adding SSR to a route, wiring Express/Next render pipelines, or choosing between SSR, SSG, and CSR.
+
+## When to use
+
+Adding SSR to pages/server code; debugging hydration mismatches or "window is not defined" errors; deciding SSR vs SSG vs CSR; serialising initial state for client takeover.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/server-ssr
+```
+
+Or copy the [`server-ssr/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/pages/**/*.{jsx,tsx,vue}`
+- `**/server/**/*.{js,ts}`
+- `**/*ssr*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-actions/README.md
+++ b/skills/state-actions/README.md
@@ -1,0 +1,34 @@
+# State Actions
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-actions)
+
+> `state-actions` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/failure patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
+
+## When to use
+
+Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/failure); enforcing FSA compliance and serialisable payloads.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-actions
+```
+
+Or copy the [`state-actions/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/actions/**/*.{js,ts}`
+- `**/*Actions*.{js,ts}`
+- `**/*slice*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-ajax/README.md
+++ b/skills/state-ajax/README.md
@@ -1,0 +1,33 @@
+# State AJAX
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-ajax)
+
+> `state-ajax` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Async data-fetching patterns — Fetch vs Axios, service-layer organisation, AbortController cancellation, and integration with Redux Toolkit's createAsyncThunk for pending/fulfilled/rejected state transitions. Use when writing or reviewing HTTP call sites, standardising loading/error handling, or wiring request cancellation in effects.
+
+## When to use
+
+Choosing between fetch and axios; setting up an apiClient with interceptors; integrating async requests with Redux/NgRx slices; cancelling in-flight requests on unmount via AbortController; handling loading/error/success state uniformly.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-ajax
+```
+
+Or copy the [`state-ajax/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/api/**/*.{js,ts}`
+- `**/services/**/*.{js,ts}`
+- `**/store/**/*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-crud/README.md
+++ b/skills/state-crud/README.md
@@ -1,0 +1,33 @@
+# State CRUD
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-crud)
+
+> `state-crud` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/failure triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
+
+## When to use
+
+Designing a new entity slice (todos, users, products); standardising request/success/failure naming across async operations; normalising state from arrays to byId/allIds; wiring RTK createAsyncThunks for all four CRUD ops.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-crud
+```
+
+Or copy the [`state-crud/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/slices/**/*.{js,ts}`
+- `**/*Actions*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-middleware/README.md
+++ b/skills/state-middleware/README.md
@@ -1,0 +1,33 @@
+# State Middleware
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-middleware)
+
+> `state-middleware` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Redux middleware — the `store => next => action => {}` pipeline for side effects, logging, analytics, and async (thunk/saga). Use when writing custom middleware, wiring async thunks, ordering middleware in configureStore, or keeping side effects out of reducers.
+
+## When to use
+
+Adding logger/analytics/crash-reporting middleware; writing a custom thunk-style middleware; ordering middleware in configureStore (logger last); moving side effects out of reducers.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-middleware
+```
+
+Or copy the [`state-middleware/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/middleware/**/*.{js,ts}`
+- `**/*Middleware*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-operations/README.md
+++ b/skills/state-operations/README.md
@@ -1,0 +1,33 @@
+# State Operations
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-operations)
+
+> `state-operations` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Async operation patterns — explicit idle/loading/succeeded/failed status tracking, optimistic updates with rollback, debouncing/batching, and race-condition handling via request cancellation. Use when designing async workflows, wiring createAsyncThunk pending/fulfilled/rejected handlers, or fixing stale-data bugs from out-of-order responses.
+
+## When to use
+
+Tracking loading/success/error per operation; implementing optimistic UI with rollback on failure; debouncing search/autosave; cancelling stale requests to avoid race conditions; showing skeleton/error/empty states uniformly.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-operations
+```
+
+Or copy the [`state-operations/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/operations/**/*.{js,ts}`
+- `**/*thunk*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-reducer/README.md
+++ b/skills/state-reducer/README.md
@@ -1,0 +1,34 @@
+# State Reducer
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-reducer)
+
+> `state-reducer` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Reducer design — pure `(state, action) => newState` functions, immutable updates (spread or Immer), default-case handling, and combineReducers composition. Use when writing or reviewing slice reducers, fixing accidental mutations, or splitting a monolithic reducer by domain.
+
+## When to use
+
+Writing new reducers or RTK slices; auditing for accidental state mutation or impure operations (Date.now, fetch) inside reducers; composing reducers with combineReducers; testing reducer cases in isolation.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-reducer
+```
+
+Or copy the [`state-reducer/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/reducers/**/*.{js,ts}`
+- `**/*Reducer*.{js,ts}`
+- `**/*slice*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-selectors/README.md
+++ b/skills/state-selectors/README.md
@@ -1,0 +1,34 @@
+# State Selectors
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-selectors)
+
+> `state-selectors` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Selector functions for reading state — Reselect/createSelector memoisation, input-selector composition, parameterised selector factories, and colocating selectors with slices. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind `selectXxx` helpers.
+
+## When to use
+
+Writing `selectXxx` helpers colocated with slices; memoising derived data (filtered/sorted lists, aggregated stats) with createSelector; factoring parameterised selectors (selectTodoById); replacing raw `state.x.y` access in components.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-selectors
+```
+
+Or copy the [`state-selectors/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/selectors/**/*.{js,ts}`
+- `**/*Selectors*.{js,ts}`
+- `**/*slice*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-state/README.md
+++ b/skills/state-state/README.md
@@ -1,0 +1,33 @@
+# State State
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-state)
+
+> `state-state` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+State-management fundamentals — deciding between local (useState), lifted, global (Redux/Zustand), server (React Query), and URL state; single-source-of-truth rules; unidirectional data flow. Use when choosing where a piece of data should live, refactoring prop-drilling, or introducing server-state caching.
+
+## When to use
+
+Deciding local vs lifted vs global vs server vs URL state for new data; eliminating duplicated state; replacing manual fetch + useState with React Query/RTK Query; moving shareable filters into URL searchParams.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-state
+```
+
+Or copy the [`state-state/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/state/**/*.{js,ts}`
+- `**/store/**/*.{js,ts}`
+- `**/*State*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/state-store/README.md
+++ b/skills/state-store/README.md
@@ -1,0 +1,34 @@
+# State Store
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/state-store)
+
+> `state-store` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Redux store architecture — configureStore setup, slice organisation by domain, normalised state shape, Provider wiring, typed hooks (useAppDispatch/useAppSelector), and DevTools. Use when scaffolding a new Redux store, splitting state into slices, or auditing state shape for normalisation and serialisability.
+
+## When to use
+
+Scaffolding a new configureStore; organising slices by domain; enforcing a single-store rule; shaping state as `{ byId, allIds }`; wiring `<Provider>` and typed hooks at the app root.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/state-store
+```
+
+Or copy the [`state-store/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/store/**/*.{js,ts}`
+- `**/redux/**/*.{js,ts}`
+- `**/*Store*.{js,ts}`
+- `**/*slice*.{js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-accessibility/README.md
+++ b/skills/ui-accessibility/README.md
@@ -1,0 +1,32 @@
+# UI Accessibility
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-accessibility)
+
+> `ui-accessibility` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Web accessibility (a11y) patterns — semantic HTML, ARIA attributes, keyboard navigation (Tab/Enter/Space/Arrows), focus management, colour contrast, and WCAG POUR principles. Use when reviewing components for a11y compliance, adding aria-labels to icon-only buttons, or wiring arrow-key navigation for custom dropdowns/menus.
+
+## When to use
+
+Reviewing components for WCAG AA compliance; replacing `<div onclick>` with semantic HTML; adding ARIA roles/labels for custom widgets; implementing keyboard navigation or focus traps in modals; auditing colour contrast.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-accessibility
+```
+
+Or copy the [`ui-accessibility/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-atom/README.md
+++ b/skills/ui-atom/README.md
@@ -1,0 +1,33 @@
+# UI Atom
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-atom)
+
+> `ui-atom` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Atomic-design guidance for UI Atoms — the smallest single-purpose building blocks (buttons, inputs, icons, labels). Use when authoring or reviewing components under ui/atoms, components/atoms, or when deciding whether a component belongs at the atom level.
+
+## When to use
+
+Creating or reviewing Atom-level components; deciding whether a component is an atom vs. molecule; enforcing single-responsibility and design-token consumption in primitives.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-atom
+```
+
+Or copy the [`ui-atom/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/atoms/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/atoms/**/*`
+- `**/atoms/**/*`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-atomic-design/README.md
+++ b/skills/ui-atomic-design/README.md
@@ -1,0 +1,32 @@
+# UI Atomic Design
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-atomic-design)
+
+> `ui-atomic-design` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Atomic-design methodology — five-level component hierarchy (Atoms → Molecules → Organisms → Templates → Pages) as a shared vocabulary and folder-structure convention. Use when organising a new UI library, deciding which folder a component belongs in, or onboarding a team to the atomic-design vocabulary.
+
+## When to use
+
+Laying out an atoms/molecules/organisms/templates/pages folder structure; classifying a new component by level; resolving team debates about whether something is a molecule or organism; teaching the vocabulary.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-atomic-design
+```
+
+Or copy the [`ui-atomic-design/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-attributes/README.md
+++ b/skills/ui-attributes/README.md
@@ -1,0 +1,32 @@
+# UI Attributes
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-attributes)
+
+> `ui-attributes` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+HTML attribute semantics — boolean attributes (presence = true), attribute-vs-property distinction, `data-*` metadata, and ARIA attributes for accessibility. Use when fixing `disabled="false"` bugs, adding custom metadata to elements, or understanding why JSX `disabled={false}` differs from HTML `disabled="false"`.
+
+## When to use
+
+Debugging boolean-attribute bugs (disabled="false" stays disabled); distinguishing attributes (markup) from properties (DOM); using data-* for custom metadata; wiring ARIA attributes on interactive elements.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-attributes
+```
+
+Or copy the [`ui-attributes/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts,html}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts,html}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-component/README.md
+++ b/skills/ui-component/README.md
@@ -1,0 +1,32 @@
+# UI Component
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-component)
+
+> `ui-component` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+General component design — encapsulation of HTML/CSS/JS, single-responsibility, framework-agnostic patterns (props in, events out), colocated styles, and isolation-testable units. Use when reviewing any component's structure, refactoring a god component, or writing a native Web Component.
+
+## When to use
+
+Reviewing a component for single-responsibility and encapsulation; splitting a "god component" that does too much; wiring props-in/events-out boundaries; authoring native custom elements with Shadow DOM.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-component
+```
+
+Or copy the [`ui-component/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-dom/README.md
+++ b/skills/ui-dom/README.md
@@ -1,0 +1,32 @@
+# UI DOM
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-dom)
+
+> `ui-dom` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+DOM manipulation essentials — querySelector, textContent vs innerHTML (XSS risk), DocumentFragment batching to avoid reflow, and why direct DOM mutation inside React/Vue breaks reconciliation. Use when writing vanilla JS helpers, deciding between refs and querySelector, or debugging framework-vs-DOM conflicts.
+
+## When to use
+
+Writing vanilla-JS DOM code; batching inserts via DocumentFragment; using refs instead of querySelector inside React/Vue; avoiding innerHTML with untrusted input; understanding HTML source vs live DOM.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-dom
+```
+
+Or copy the [`ui-dom/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-element/README.md
+++ b/skills/ui-element/README.md
@@ -1,0 +1,32 @@
+# UI Element
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-element)
+
+> `ui-element` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Element concepts — the distinction between Component (blueprint), Element (`{ type, props }` description object), and DOM node (browser primitive), plus custom-element registration via `customElements.define`. Use when teaching the JSX→createElement→DOM pipeline or registering Web Components with observedAttributes lifecycle.
+
+## When to use
+
+Clarifying Component vs Element vs DOM-node terminology; reading how JSX desugars to createElement calls; registering custom elements with observedAttributes/attributeChangedCallback; waiting on customElements.whenDefined.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-element
+```
+
+Or copy the [`ui-element/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-events/README.md
+++ b/skills/ui-events/README.md
@@ -1,0 +1,32 @@
+# UI Events
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-events)
+
+> `ui-events` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+DOM event handling — capture/target/bubble phases, event delegation (one listener on a parent via `event.target.closest`), preventDefault vs stopPropagation, passive scroll listeners, and useEffect cleanup to avoid leaks. Use when wiring click/keyboard/scroll handlers, fixing listener memory leaks, or optimising lists with delegation.
+
+## When to use
+
+Delegating click handling from many children to one parent; wiring keyboard support (Enter/Space) alongside click; adding passive scroll/touch listeners; cleaning up listeners in useEffect return; choosing preventDefault vs stopPropagation.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-events
+```
+
+Or copy the [`ui-events/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-molecule/README.md
+++ b/skills/ui-molecule/README.md
@@ -1,0 +1,33 @@
+# UI Molecule
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-molecule)
+
+> `ui-molecule` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Atomic-design guidance for Molecules — functional groups of atoms (SearchBar = input + button + icon; FormField = label + input + error) with a single cohesive purpose. Use when authoring or reviewing components under ui/molecules, composing atoms, or deciding atom vs molecule vs organism.
+
+## When to use
+
+Creating or reviewing molecule-level components; deciding whether a component is a molecule vs. an organism (no store connection = molecule); composing atoms without recreating their functionality; keeping molecules purely presentational.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-molecule
+```
+
+Or copy the [`ui-molecule/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/molecules/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/molecules/**/*`
+- `**/molecules/**/*`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-organism/README.md
+++ b/skills/ui-organism/README.md
@@ -1,0 +1,33 @@
+# UI Organism
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-organism)
+
+> `ui-organism` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Atomic-design guidance for Organisms — complex feature-level sections (Header, ProductGrid, CommentSection) that compose molecules, connect to state, handle loading/error/empty states, and own responsive layout decisions. Use when authoring components under ui/organisms or deciding molecule vs organism boundaries.
+
+## When to use
+
+Creating or reviewing organism-level components; wiring data fetching and store hooks at the organism boundary; keeping loading/error/empty states at this layer (not in molecules); defining responsive breakpoint behaviour per feature.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-organism
+```
+
+Or copy the [`ui-organism/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/organisms/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/organisms/**/*`
+- `**/organisms/**/*`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-props/README.md
+++ b/skills/ui-props/README.md
@@ -1,0 +1,32 @@
+# UI Props
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-props)
+
+> `ui-props` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Component props design — read-only data passed parent→child, unidirectional flow with callback props for child→parent events, typed interfaces (TypeScript/PropTypes), and sensible defaults. Use when designing a component's public API, auditing prop names/counts, or fixing code that mutates props.
+
+## When to use
+
+Designing or reviewing a component's prop interface; replacing prop mutation with callback patterns; typing props with TypeScript/PropTypes; trimming bloated prop lists; picking default values for optional props.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-props
+```
+
+Or copy the [`ui-props/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/components/**/*.{jsx,tsx,vue,js,ts}`
+- `**/ui/**/*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-skeleton/README.md
+++ b/skills/ui-skeleton/README.md
@@ -1,0 +1,33 @@
+# UI Skeleton
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-skeleton)
+
+> `ui-skeleton` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Skeleton loading placeholders — gray-shape stand-ins that mirror final content dimensions, use subtle shimmer/pulse animation, and prevent layout shift. Use when replacing generic spinners with content-shaped placeholders, reducing perceived latency on slow routes, or preventing CLS on image-heavy cards.
+
+## When to use
+
+Replacing generic spinners with content-shaped placeholders (CardSkeleton, ListSkeleton); preventing layout shift (CLS) during data load; designing shimmer/pulse animations; deciding when not to show a skeleton (<200ms loads).
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-skeleton
+```
+
+Or copy the [`ui-skeleton/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/skeletons/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/skeletons/**/*`
+- `**/*Skeleton*.{jsx,tsx,vue,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-story/README.md
+++ b/skills/ui-story/README.md
@@ -1,0 +1,32 @@
+# UI Story
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-story)
+
+> `ui-story` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Storybook story authoring — Component Story Format (CSF) with default-export metadata and named-export stories, argTypes for Controls, play functions for interaction tests, and coverage of edge states (empty/error/loading/long-text). Use when writing `.stories.jsx/ts` files or reviewing Storybook coverage for a component.
+
+## When to use
+
+Writing or reviewing `.stories.{js,jsx,ts,tsx}` files; adding argTypes for the Controls addon; covering edge-case states (empty/error/loading/long-text/icon-only); wiring play functions for interaction testing.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-story
+```
+
+Or copy the [`ui-story/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/*.stories.{js,jsx,ts,tsx}`
+- `**/*.story.{js,jsx,ts,tsx}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-template/README.md
+++ b/skills/ui-template/README.md
@@ -1,0 +1,34 @@
+# UI Template
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-template)
+
+> `ui-template` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Atomic-design guidance for Templates — page-level wireframes that arrange organisms into layout slots (hero/main/sidebar/footer) without fetching data. Use when authoring components under ui/templates, defining reusable page skeletons, or keeping layout decisions out of pages and organisms.
+
+## When to use
+
+Creating a reusable page layout that accepts content via slots/props; keeping data fetching out of templates (it belongs in pages); defining responsive breakpoints at the layout level; separating layout concerns from organism concerns.
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-template
+```
+
+Or copy the [`ui-template/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/ui/templates/**/*.{jsx,tsx,vue,js,ts}`
+- `**/components/templates/**/*`
+- `**/templates/**/*`
+- `**/layouts/**/*`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.

--- a/skills/ui-theme/README.md
+++ b/skills/ui-theme/README.md
@@ -1,0 +1,34 @@
+# UI Theme
+
+[![skills.sh](https://skills.sh/b/grvpanchal/elegant)](https://skills.sh/grvpanchal/elegant/ui-theme)
+
+> `ui-theme` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
+
+Design-token systems — semantic CSS custom properties for colours, spacing, typography, and shadows, with light/dark theme switching via `[data-theme]` overrides. Use when setting up a token catalogue, auditing components for hardcoded colours/magic numbers, or adding dark-mode support via token swaps.
+
+## When to use
+
+Setting up or extending a design-token catalogue; replacing hardcoded colours/spacing with `var(--token)` references; implementing dark-mode via `[data-theme="dark"]` overrides; enforcing semantic names (--color-error) over value names (--color-red).
+
+## Install
+
+Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
+
+```sh
+npx skills add grvpanchal/elegant/ui-theme
+```
+
+Or copy the [`ui-theme/`](.) folder into `~/.claude/skills/`.
+
+## Auto-activates on
+
+Agents surface this skill when editing files matching:
+
+- `**/theme/**/*.{css,scss,less}`
+- `**/styles/**/*.{css,scss,less}`
+- `**/tokens/**/*`
+- `**/*theme*.{css,js,ts}`
+
+## Full guidance
+
+See [`SKILL.md`](./SKILL.md) for the complete pattern, examples, and review checklist.


### PR DESCRIPTION
Add skills/README.md cataloguing all 35 Agent Skills grouped by UI,
State, and Server layers, and surface a skills badge plus a short
Agent Skills section in the root README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD