### PR TITLE
docs: add per-skill READMEs with skills.sh badges

### DIFF
--- a/skills/server-api/README.md
+++ b/skills/server-api/README.md
@@ -15,7 +15,7 @@ Creating or refactoring API clients and service modules; adding auth-refresh or 
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-api
+npx skills add grvpanchal/elegant --skill server-api
 ```
 
 Or copy the [`server-api/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-app-shell/README.md
+++ b/skills/server-app-shell/README.md
@@ -15,7 +15,7 @@ Designing the root layout and service-worker cache strategy for a PWA; separatin
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-app-shell
+npx skills add grvpanchal/elegant --skill server-app-shell
 ```
 
 Or copy the [`server-app-shell/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-authentication/README.md
+++ b/skills/server-authentication/README.md
@@ -15,7 +15,7 @@ Implementing login/logout and session bootstrap; wiring access/refresh-token ref
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-authentication
+npx skills add grvpanchal/elegant --skill server-authentication
 ```
 
 Or copy the [`server-authentication/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-container/README.md
+++ b/skills/server-container/README.md
@@ -15,7 +15,7 @@ Splitting a component into container + presentational pair; connecting a view to
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-container
+npx skills add grvpanchal/elegant --skill server-container
 ```
 
 Or copy the [`server-container/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-mfe/README.md
+++ b/skills/server-mfe/README.md
@@ -15,7 +15,7 @@ Splitting a UI by bounded context or team ownership; configuring Module Federati
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-mfe
+npx skills add grvpanchal/elegant --skill server-mfe
 ```
 
 Or copy the [`server-mfe/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-page/README.md
+++ b/skills/server-page/README.md
@@ -15,7 +15,7 @@ Adding a new route/page file; deciding between getServerSideProps, getStaticProp
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-page
+npx skills add grvpanchal/elegant --skill server-page
 ```
 
 Or copy the [`server-page/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-protocol/README.md
+++ b/skills/server-protocol/README.md
@@ -15,7 +15,7 @@ Setting up HTTPS in production or local dev (mkcert, Vite https); configuring HS
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-protocol
+npx skills add grvpanchal/elegant --skill server-protocol
 ```
 
 Or copy the [`server-protocol/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-proxy/README.md
+++ b/skills/server-proxy/README.md
@@ -15,7 +15,7 @@ Configuring Vite/webpack/CRA dev proxies to avoid CORS; writing Nginx/Cloudflare
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-proxy
+npx skills add grvpanchal/elegant --skill server-proxy
 ```
 
 Or copy the [`server-proxy/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-router/README.md
+++ b/skills/server-router/README.md
@@ -15,7 +15,7 @@ Setting up or restructuring the route table; extracting params with useParams/us
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-router
+npx skills add grvpanchal/elegant --skill server-router
 ```
 
 Or copy the [`server-router/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-ssg/README.md
+++ b/skills/server-ssg/README.md
@@ -15,7 +15,7 @@ Deciding SSG vs SSR vs CSR for a given page; setting up getStaticProps/getStatic
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-ssg
+npx skills add grvpanchal/elegant --skill server-ssg
 ```
 
 Or copy the [`server-ssg/`](.) folder into `~/.claude/skills/`.

--- a/skills/server-ssr/README.md
+++ b/skills/server-ssr/README.md
@@ -15,7 +15,7 @@ Adding SSR to pages/server code; debugging hydration mismatches or "window is no
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/server-ssr
+npx skills add grvpanchal/elegant --skill server-ssr
 ```
 
 Or copy the [`server-ssr/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-actions/README.md
+++ b/skills/state-actions/README.md
@@ -15,7 +15,7 @@ Authoring or reviewing action creators, type constants, or RTK slice reducers; d
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-actions
+npx skills add grvpanchal/elegant --skill state-actions
 ```
 
 Or copy the [`state-actions/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-ajax/README.md
+++ b/skills/state-ajax/README.md
@@ -15,7 +15,7 @@ Choosing between fetch and axios; setting up an apiClient with interceptors; int
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-ajax
+npx skills add grvpanchal/elegant --skill state-ajax
 ```
 
 Or copy the [`state-ajax/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-crud/README.md
+++ b/skills/state-crud/README.md
@@ -15,7 +15,7 @@ Designing a new entity slice (todos, users, products); standardising request/suc
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-crud
+npx skills add grvpanchal/elegant --skill state-crud
 ```
 
 Or copy the [`state-crud/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-middleware/README.md
+++ b/skills/state-middleware/README.md
@@ -15,7 +15,7 @@ Adding logger/analytics/crash-reporting middleware; writing a custom thunk-style
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-middleware
+npx skills add grvpanchal/elegant --skill state-middleware
 ```
 
 Or copy the [`state-middleware/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-operations/README.md
+++ b/skills/state-operations/README.md
@@ -15,7 +15,7 @@ Tracking loading/success/error per operation; implementing optimistic UI with ro
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-operations
+npx skills add grvpanchal/elegant --skill state-operations
 ```
 
 Or copy the [`state-operations/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-reducer/README.md
+++ b/skills/state-reducer/README.md
@@ -15,7 +15,7 @@ Writing new reducers or RTK slices; auditing for accidental state mutation or im
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-reducer
+npx skills add grvpanchal/elegant --skill state-reducer
 ```
 
 Or copy the [`state-reducer/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-selectors/README.md
+++ b/skills/state-selectors/README.md
@@ -15,7 +15,7 @@ Writing `selectXxx` helpers colocated with slices; memoising derived data (filte
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-selectors
+npx skills add grvpanchal/elegant --skill state-selectors
 ```
 
 Or copy the [`state-selectors/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-state/README.md
+++ b/skills/state-state/README.md
@@ -15,7 +15,7 @@ Deciding local vs lifted vs global vs server vs URL state for new data; eliminat
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-state
+npx skills add grvpanchal/elegant --skill state-state
 ```
 
 Or copy the [`state-state/`](.) folder into `~/.claude/skills/`.

--- a/skills/state-store/README.md
+++ b/skills/state-store/README.md
@@ -15,7 +15,7 @@ Scaffolding a new configureStore; organising slices by domain; enforcing a singl
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/state-store
+npx skills add grvpanchal/elegant --skill state-store
 ```
 
 Or copy the [`state-store/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-accessibility/README.md
+++ b/skills/ui-accessibility/README.md
@@ -15,7 +15,7 @@ Reviewing components for WCAG AA compliance; replacing `<div onclick>` with sema
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-accessibility
+npx skills add grvpanchal/elegant --skill ui-accessibility
 ```
 
 Or copy the [`ui-accessibility/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-atom/README.md
+++ b/skills/ui-atom/README.md
@@ -15,7 +15,7 @@ Creating or reviewing Atom-level components; deciding whether a component is an 
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-atom
+npx skills add grvpanchal/elegant --skill ui-atom
 ```
 
 Or copy the [`ui-atom/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-atomic-design/README.md
+++ b/skills/ui-atomic-design/README.md
@@ -15,7 +15,7 @@ Laying out an atoms/molecules/organisms/templates/pages folder structure; classi
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-atomic-design
+npx skills add grvpanchal/elegant --skill ui-atomic-design
 ```
 
 Or copy the [`ui-atomic-design/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-attributes/README.md
+++ b/skills/ui-attributes/README.md
@@ -15,7 +15,7 @@ Debugging boolean-attribute bugs (disabled="false" stays disabled); distinguishi
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-attributes
+npx skills add grvpanchal/elegant --skill ui-attributes
 ```
 
 Or copy the [`ui-attributes/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-component/README.md
+++ b/skills/ui-component/README.md
@@ -15,7 +15,7 @@ Reviewing a component for single-responsibility and encapsulation; splitting a "
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-component
+npx skills add grvpanchal/elegant --skill ui-component
 ```
 
 Or copy the [`ui-component/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-dom/README.md
+++ b/skills/ui-dom/README.md
@@ -15,7 +15,7 @@ Writing vanilla-JS DOM code; batching inserts via DocumentFragment; using refs i
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-dom
+npx skills add grvpanchal/elegant --skill ui-dom
 ```
 
 Or copy the [`ui-dom/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-element/README.md
+++ b/skills/ui-element/README.md
@@ -15,7 +15,7 @@ Clarifying Component vs Element vs DOM-node terminology; reading how JSX desugar
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-element
+npx skills add grvpanchal/elegant --skill ui-element
 ```
 
 Or copy the [`ui-element/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-events/README.md
+++ b/skills/ui-events/README.md
@@ -15,7 +15,7 @@ Delegating click handling from many children to one parent; wiring keyboard supp
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-events
+npx skills add grvpanchal/elegant --skill ui-events
 ```
 
 Or copy the [`ui-events/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-molecule/README.md
+++ b/skills/ui-molecule/README.md
@@ -15,7 +15,7 @@ Creating or reviewing molecule-level components; deciding whether a component is
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-molecule
+npx skills add grvpanchal/elegant --skill ui-molecule
 ```
 
 Or copy the [`ui-molecule/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-organism/README.md
+++ b/skills/ui-organism/README.md
@@ -15,7 +15,7 @@ Creating or reviewing organism-level components; wiring data fetching and store 
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-organism
+npx skills add grvpanchal/elegant --skill ui-organism
 ```
 
 Or copy the [`ui-organism/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-props/README.md
+++ b/skills/ui-props/README.md
@@ -15,7 +15,7 @@ Designing or reviewing a component's prop interface; replacing prop mutation wit
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-props
+npx skills add grvpanchal/elegant --skill ui-props
 ```
 
 Or copy the [`ui-props/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-skeleton/README.md
+++ b/skills/ui-skeleton/README.md
@@ -15,7 +15,7 @@ Replacing generic spinners with content-shaped placeholders (CardSkeleton, ListS
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-skeleton
+npx skills add grvpanchal/elegant --skill ui-skeleton
 ```
 
 Or copy the [`ui-skeleton/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-story/README.md
+++ b/skills/ui-story/README.md
@@ -15,7 +15,7 @@ Writing or reviewing `.stories.{js,jsx,ts,tsx}` files; adding argTypes for the C
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-story
+npx skills add grvpanchal/elegant --skill ui-story
 ```
 
 Or copy the [`ui-story/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-template/README.md
+++ b/skills/ui-template/README.md
@@ -15,7 +15,7 @@ Creating a reusable page layout that accepts content via slots/props; keeping da
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-template
+npx skills add grvpanchal/elegant --skill ui-template
 ```
 
 Or copy the [`ui-template/`](.) folder into `~/.claude/skills/`.

--- a/skills/ui-theme/README.md
+++ b/skills/ui-theme/README.md
@@ -15,7 +15,7 @@ Setting up or extending a design-token catalogue; replacing hardcoded colours/sp
 Add this skill to your agent with the [skills.sh](https://skills.sh) CLI:
 
 ```sh
-npx skills add grvpanchal/elegant/ui-theme
+npx skills add grvpanchal/elegant --skill ui-theme
 ```
 
 Or copy the [`ui-theme/`](.) folder into `~/.claude/skills/`.


### PR DESCRIPTION
## Summary

Adds documentation for the Agent Skills under `skills/`:

- **A `README.md` in each of the 35 skill folders**, generated from each `SKILL.md` frontmatter. Each one includes:
  - A **skills.sh badge** linking to that skill's page
  - The skill's description and **When to use**
  - An **Install** command — `npx skills add grvpanchal/elegant --skill <skill>`
  - **Auto-activates on** — the `paths` globs from the frontmatter
  - A link to the full `SKILL.md`
- **A catalogue `skills/README.md`** indexing all 35 skills grouped by UI / State / Server layer.
- A **skills.sh badge** + short "Agent Skills" section on the root `README.md`.

## Notes

- Badge format follows skills.sh's documented install-count badge: `https://skills.sh/b/grvpanchal/elegant`. It's repo-level, so the image is shared; each badge links to its own skill page.
- No template code, CLI code, or docs under `docs/{ui,server,state}/` were touched — docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD)_