### PR TITLE
fix(skills): re-evaluate terminology against the templates

### DIFF
--- a/skills/server-container/SKILL.md
+++ b/skills/server-container/SKILL.md
@@ -40,51 +40,74 @@ Containers are "smart" components that handle data fetching, state management, a
 
 ### Container/Presentational Pattern
 
+The container is the **connection point**: it reads the store, builds a `data` value and an `events` object, and passes them to a purely presentational organism. The organism (`TodoList`) never connects to state directly — state → container → organism.
+
 ```jsx
-// TodoListContainer.jsx - SMART (Container)
-import { useSelector, useDispatch } from 'react-redux';
-import { fetchTodos, toggleTodo } from '../state/todoSlice';
-import TodoList from '../components/TodoList';  // DUMB
+// TodoListContainer.jsx - SMART (Container), connects state to the organism
+import TodoList from '../ui/organisms/TodoList/TodoList.component';  // DUMB organism
+import { useDispatch, useSelector } from 'react-redux';
+import { createTodo, deleteTodo, readTodo, toggleTodo } from '../state/todo/todo.actions';
+import { getSelectedFilter } from '../state/filters/filters.selectors';
+import { getVisibleTodos } from '../state/todo/todo.selectors';
+import { useEffect } from 'react';
 
-const TodoListContainer = () => {
+export default function TodoListContainer() {
   const dispatch = useDispatch();
-  const { todos, loading, error } = useSelector(state => state.todos);
-  
-  useEffect(() => {
-    dispatch(fetchTodos());
-  }, [dispatch]);
-  
-  const handleToggle = (id) => dispatch(toggleTodo(id));
-  
-  return (
-    <TodoList
-      todos={todos}
-      loading={loading}
-      error={error}
-      onToggle={handleToggle}
-    />
+  const selectedFilter = useSelector(getSelectedFilter);
+  const todoData = useSelector((state) =>
+    getVisibleTodos(state.todo, selectedFilter.id)
   );
-};
 
-// TodoList.jsx - DUMB (Presentational)
-const TodoList = ({ todos, loading, error, onToggle }) => {
-  if (loading) return <LoadingSpinner />;
-  if (error) return <ErrorMessage error={error} />;
-  if (!todos.length) return <EmptyState />;
-  
-  return (
-    <ul>
-      {todos.map(todo => (
-        <TodoItem 
-          key={todo.id} 
-          todo={todo} 
-          onToggle={() => onToggle(todo.id)} 
-        />
-      ))}
-    </ul>
-  );
-};
+  useEffect(() => {
+    dispatch(readTodo());
+  }, [dispatch]);
+
+  const events = {
+    onTodoCreate: (payload) => dispatch(createTodo(payload)),
+    onTodoToggleUpdate: (id) => dispatch(toggleTodo(id)),
+    onTodoDelete: (payload) => dispatch(deleteTodo(payload)),
+  };
+
+  // Container passes `data` + `events` to the presentational organism
+  return <TodoList todoData={todoData} events={events} />;
+}
+
+// TodoList.component.jsx - DUMB (Presentational organism): props in, events out, no store
+const TodoList = ({ todoData, events }) => (
+  <ul>
+    {todoData.items.map((todo) => (
+      <TodoItem
+        key={todo.id}
+        todo={todo}
+        onToggle={() => events.onTodoToggleUpdate(todo.id)}
+      />
+    ))}
+  </ul>
+);
 ```
+
+The same shape applies with Zustand — only the store-read changes (`useStore` instead of `useSelector`/`useDispatch`), while the `data` + `events` hand-off to the organism is identical:
+
+```jsx
+// TodoListContainer.jsx (Zustand variant)
+import useStore from '../state';
+
+export default function TodoListContainer() {
+  const selectedFilter = useStore(getSelectedFilter);
+  const todoState = useStore((state) => state.todo);
+  const todoData = getVisibleTodos(todoState, selectedFilter.id);
+
+  const readTodo = useStore((state) => state.readTodo);
+  const toggleTodo = useStore((state) => state.toggleTodo);
+
+  useEffect(() => { readTodo(); }, [readTodo]);
+
+  const events = { onTodoToggleUpdate: (id) => toggleTodo(id) };
+  return <TodoList todoData={todoData} events={events} />;
+}
+```
+
+A container can also be side-effect only — reading state and returning `null` (e.g. `ConfigContainer.js` toggles the `dark` body class from `state.config.theme`).
 
 ### Modern Hook-Based Pattern
 
@@ -121,16 +144,16 @@ const TodoListContainer = () => {
 ### Testing Benefits
 
 ```jsx
-// Presentational component easy to test
+// Presentational organism easy to test (Vitest)
 test('TodoList renders items', () => {
-  const mockTodos = [{ id: 1, text: 'Test', completed: false }];
-  
-  render(<TodoList todos={mockTodos} onToggle={jest.fn()} />);
-  
+  const todoData = { items: [{ id: 1, text: 'Test', completed: false }] };
+
+  render(<TodoList todoData={todoData} events={{ onTodoToggleUpdate: vi.fn() }} />);
+
   expect(screen.getByText('Test')).toBeInTheDocument();
 });
 
-// No Redux mocking needed for presentational!
+// No store mocking needed for presentational organisms!
 ```
 
 ## Related Terminologies

--- a/skills/server-page/README.md
+++ b/skills/server-page/README.md
@@ -4,11 +4,11 @@
 
 > `server-page` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-Page components — the thin data-fetching layer that binds a route to a template, invoking getServerSideProps/getStaticProps and passing props down. Use when creating a new route, choosing SSR vs SSG vs ISR for a page, or reviewing whether a page is doing template-level work it shouldn't.
+Page components — the thin route-level composition layer that binds a route to a layout template and the containers it hosts. In the elegant SPA templates a page is pure composition (no data fetching); in a Next.js app it additionally invokes getServerSideProps/getStaticProps. Use when creating a new route, composing containers inside a layout, or reviewing whether a page is doing template-level work it shouldn't.
 
 ## When to use
 
-Adding a new route/page file; deciding between getServerSideProps, getStaticProps, and ISR; wiring SEO head tags; keeping pages thin and templates dumb.
+Adding a new route/page file; composing containers inside a layout template; (Next.js only) deciding between getServerSideProps, getStaticProps, and ISR; keeping pages thin and templates dumb.
 
 ## Install
 

--- a/skills/server-page/SKILL.md
+++ b/skills/server-page/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: server-page
-description: Page components — the thin data-fetching layer that binds a route to a template, invoking getServerSideProps/getStaticProps and passing props down. Use when creating a new route, choosing SSR vs SSG vs ISR for a page, or reviewing whether a page is doing template-level work it shouldn't.
-when_to_use: Adding a new route/page file; deciding between getServerSideProps, getStaticProps, and ISR; wiring SEO head tags; keeping pages thin and templates dumb.
+description: Page components — the thin route-level composition layer that binds a route to a layout template and the containers it hosts. In the elegant SPA templates a page is pure composition (no data fetching); in a Next.js app it additionally invokes getServerSideProps/getStaticProps. Use when creating a new route, composing containers inside a layout, or reviewing whether a page is doing template-level work it shouldn't.
+when_to_use: Adding a new route/page file; composing containers inside a layout template; (Next.js only) deciding between getServerSideProps, getStaticProps, and ISR; keeping pages thin and templates dumb.
 paths:
   - "**/pages/**/*.{jsx,tsx,vue}"
   - "**/app/**/*.{jsx,tsx}"
@@ -11,13 +11,31 @@ paths:
 
 ## What is a Page?
 
-Pages are concrete instances of templates filled with real data—where abstract layouts meet actual content. ProductTemplate + iPhone data = iPhone Product Page. Pages handle data fetching (SSR/SSG) and pass props to templates.
+A page is the thin composition layer that maps a route to a layout template and the containers that fill it. In the elegant SPA templates a page composes containers inside a layout — it does **not** fetch data (the templates are client-side SPAs with no `getServerSideProps`/`getStaticProps`); state reaches the UI through containers. In a Next.js app, a page additionally becomes the data-fetching boundary (`getServerSideProps`/`getStaticProps`) — the pattern below covers both.
+
+```jsx
+// src/pages/index.jsx (elegant SPA) — route-level composition of containers in a layout
+import SiteHeaderContainer from '../containers/SiteHeaderContainer';
+import TodoFiltersContainer from '../containers/TodoFiltersContainer';
+import TodoListContainer from '../containers/TodoListContainer';
+import Layout from '../ui/templates/Layout/Layout.component';
+
+export default function HomePage() {
+  return (
+    <Layout>
+      <SiteHeaderContainer />
+      <TodoListContainer />
+      <TodoFiltersContainer />
+    </Layout>
+  );
+}
+```
 
 ## Key Principles
 
-1. **Template + Data = Page**: Templates define structure (slots), pages fill those slots with fetched data. Same template, different pages.
+1. **Template + Containers = Page**: Templates define structure (slots/layout); pages fill those slots with containers (elegant SPA) or fetched data (Next.js). Same template, different pages.
 
-2. **Data Fetching Boundary**: Pages are where `getServerSideProps`/`getStaticProps` live. Pages fetch, templates render.
+2. **Data Fetching Boundary (Next.js)**: In a Next.js app, pages are where `getServerSideProps`/`getStaticProps` live — pages fetch, templates render. The elegant SPA templates have no such hooks; data flows in via containers instead.
 
 3. **Route Mapping**: Pages correspond to URLs. `/products/[id].js` creates pages for `/products/1`, `/products/2`, etc.
 

--- a/skills/state-actions/README.md
+++ b/skills/state-actions/README.md
@@ -4,11 +4,11 @@
 
 > `state-actions` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/failure patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
+Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/error patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
 
 ## When to use
 
-Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/failure); enforcing FSA compliance and serialisable payloads.
+Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/error); enforcing FSA compliance and serialisable payloads.
 
 ## Install
 

--- a/skills/state-actions/SKILL.md
+++ b/skills/state-actions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: state-actions
-description: Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/failure patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
-when_to_use: Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/failure); enforcing FSA compliance and serialisable payloads.
+description: Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/error patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
+when_to_use: Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/error); enforcing FSA compliance and serialisable payloads.
 paths:
   - "**/store/**/*.{js,ts}"
   - "**/actions/**/*.{js,ts}"
@@ -30,7 +30,7 @@ Actions are plain JavaScript objects describing "what happened"—not how state 
 - Follow FSA (Flux Standard Action) format
 - Use action creators to encapsulate creation
 - Define type constants to prevent typos
-- Use request/success/failure for async actions
+- Use request/success/error for async actions
 
 ❌ **DON'T**:
 - Put non-serializable values in actions
@@ -105,7 +105,7 @@ export const { addTodo, toggleTodo } = todosSlice.actions;
 ### Async Action Pattern
 
 ```javascript
-// Request/Success/Failure pattern
+// Request/Success/Error pattern
 export const fetchUsers = createAsyncThunk(
   'users/fetch',
   async (_, { rejectWithValue }) => {
@@ -179,7 +179,7 @@ function TodoForm() {
 - [ ] Actions are plain objects
 - [ ] Type follows domain/event naming
 - [ ] Payloads are serializable
-- [ ] Async uses request/success/failure
+- [ ] Async uses request/success/error
 - [ ] Action creators used for complex actions
 - [ ] TypeScript types for actions
 

--- a/skills/state-crud/README.md
+++ b/skills/state-crud/README.md
@@ -4,11 +4,11 @@
 
 > `state-crud` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/failure triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
+CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/error triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
 
 ## When to use
 
-Designing a new entity slice (todos, users, products); standardising request/success/failure naming across async operations; normalising state from arrays to byId/allIds; wiring RTK createAsyncThunks for all four CRUD ops.
+Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks or sagas for all four CRUD ops.
 
 ## Install
 

--- a/skills/state-crud/SKILL.md
+++ b/skills/state-crud/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: state-crud
-description: CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/failure triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
-when_to_use: Designing a new entity slice (todos, users, products); standardising request/success/failure naming across async operations; normalising state from arrays to byId/allIds; wiring RTK createAsyncThunks for all four CRUD ops.
+description: CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/error triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
+when_to_use: Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks or sagas for all four CRUD ops.
 paths:
   - "**/store/**/*.{js,ts}"
   - "**/slices/**/*.{js,ts}"
@@ -18,7 +18,7 @@ CRUD (Create, Read, Update, Delete) are the four basic operations for persistent
 
 1. **Consistent Naming**: Use `domain/operation` pattern—`todos/create`, `todos/read`, `todos/update`, `todos/delete`. Consistency aids debugging.
 
-2. **Request/Success/Failure**: Each CRUD operation needs three action types for async handling: `todos/createRequest`, `todos/createSuccess`, `todos/createFailure`.
+2. **Request/Success/Error**: Each CRUD operation needs three action types for async handling: `todos/createRequest`, `todos/createSuccess`, `todos/createError`.
 
 3. **Normalized State**: Store entities by ID for efficient CRUD. `{ byId: { '1': {...} }, allIds: ['1'] }` enables O(1) lookups.
 
@@ -27,7 +27,7 @@ CRUD (Create, Read, Update, Delete) are the four basic operations for persistent
 ✅ **DO**:
 - Follow `domain/operationName` convention
 - Define action types as constants
-- Use request/success/failure for async
+- Use request/success/error for async
 - Normalize state for entities
 - Handle optimistic updates thoughtfully
 
@@ -47,19 +47,19 @@ CRUD (Create, Read, Update, Delete) are the four basic operations for persistent
 const TODO_ACTIONS = {
   CREATE_REQUEST: 'todos/createRequest',
   CREATE_SUCCESS: 'todos/createSuccess',
-  CREATE_FAILURE: 'todos/createFailure',
+  CREATE_ERROR: 'todos/createError',
   
   READ_REQUEST: 'todos/readRequest',
   READ_SUCCESS: 'todos/readSuccess',
-  READ_FAILURE: 'todos/readFailure',
+  READ_ERROR: 'todos/readError',
   
   UPDATE_REQUEST: 'todos/updateRequest',
   UPDATE_SUCCESS: 'todos/updateSuccess',
-  UPDATE_FAILURE: 'todos/updateFailure',
+  UPDATE_ERROR: 'todos/updateError',
   
   DELETE_REQUEST: 'todos/deleteRequest',
   DELETE_SUCCESS: 'todos/deleteSuccess',
-  DELETE_FAILURE: 'todos/deleteFailure',
+  DELETE_ERROR: 'todos/deleteError',
 };
 ```
 
@@ -195,7 +195,7 @@ function TodoManager() {
 ## Quality Gates
 
 - [ ] Consistent naming convention
-- [ ] Request/success/failure for async
+- [ ] Request/success/error for async
 - [ ] Normalized state for entities
 - [ ] Loading/error states handled
 - [ ] Optimistic updates considered

--- a/skills/state-selectors/README.md
+++ b/skills/state-selectors/README.md
@@ -4,11 +4,11 @@
 
 > `state-selectors` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-Selector functions for reading state — Reselect/createSelector memoisation, input-selector composition, parameterised selector factories, and colocating selectors with slices. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind `selectXxx` helpers.
+Selector functions for reading state — plain selector functions colocated with slices, optional Reselect/createSelector memoisation, input-selector composition, and parameterised selector factories. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind selector helpers.
 
 ## When to use
 
-Writing `selectXxx` helpers colocated with slices; memoising derived data (filtered/sorted lists, aggregated stats) with createSelector; factoring parameterised selectors (selectTodoById); replacing raw `state.x.y` access in components.
+Writing selector helpers colocated with slices; deriving data (filtered/sorted lists, aggregated stats), optionally memoising with createSelector; factoring parameterised selectors; replacing raw `state.x.y` access in components.
 
 ## Install
 

--- a/skills/state-selectors/SKILL.md
+++ b/skills/state-selectors/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: state-selectors
-description: Selector functions for reading state — Reselect/createSelector memoisation, input-selector composition, parameterised selector factories, and colocating selectors with slices. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind `selectXxx` helpers.
-when_to_use: Writing `selectXxx` helpers colocated with slices; memoising derived data (filtered/sorted lists, aggregated stats) with createSelector; factoring parameterised selectors (selectTodoById); replacing raw `state.x.y` access in components.
+description: Selector functions for reading state — plain selector functions colocated with slices, optional Reselect/createSelector memoisation, input-selector composition, and parameterised selector factories. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind selector helpers.
+when_to_use: Writing selector helpers colocated with slices; deriving data (filtered/sorted lists, aggregated stats), optionally memoising with createSelector; factoring parameterised selectors; replacing raw `state.x.y` access in components.
 paths:
   - "**/store/**/*.{js,ts}"
   - "**/selectors/**/*.{js,ts}"

--- a/skills/ui-atomic-design/SKILL.md
+++ b/skills/ui-atomic-design/SKILL.md
@@ -45,7 +45,7 @@ ATOMS        → Button, Input, Icon, Label, Image
 MOLECULES    → SearchBar, FormField, CardHeader, NavLink
   ↓            Composed of atoms, single function
 ORGANISMS    → Header, ProductGrid, CommentSection, Footer
-  ↓            Complex sections, may connect to state
+  ↓            Complex sections, stay presentational (a container connects them to state)
 TEMPLATES    → ProductPageTemplate, BlogTemplate, DashboardLayout
   ↓            Page wireframes, content slots
 PAGES        → iPhone15Page, BlogPost123, UserDashboard

--- a/skills/ui-organism/README.md
+++ b/skills/ui-organism/README.md
@@ -4,11 +4,11 @@
 
 > `ui-organism` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-Atomic-design guidance for Organisms — complex feature-level sections (Header, ProductGrid, CommentSection) that compose molecules, connect to state, handle loading/error/empty states, and own responsive layout decisions. Use when authoring components under ui/organisms or deciding molecule vs organism boundaries.
+Atomic-design guidance for Organisms — complex feature-level sections (Header, ProductGrid, CommentSection) that compose molecules, render loading/error/empty states from props, and own responsive layout decisions. Organisms stay presentational; a Container connects them to state and passes data/events down. Use when authoring components under ui/organisms or deciding molecule vs organism boundaries.
 
 ## When to use
 
-Creating or reviewing organism-level components; wiring data fetching and store hooks at the organism boundary; keeping loading/error/empty states at this layer (not in molecules); defining responsive breakpoint behaviour per feature.
+Creating or reviewing organism-level components; keeping organisms presentational (data and event callbacks arrive as props from a Container, not from store hooks inside the organism); keeping loading/error/empty rendering at this layer (not in molecules); defining responsive breakpoint behaviour per feature.
 
 ## Install
 

--- a/skills/ui-organism/SKILL.md
+++ b/skills/ui-organism/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-organism
-description: Atomic-design guidance for Organisms — complex feature-level sections (Header, ProductGrid, CommentSection) that compose molecules, connect to state, handle loading/error/empty states, and own responsive layout decisions. Use when authoring components under ui/organisms or deciding molecule vs organism boundaries.
-when_to_use: Creating or reviewing organism-level components; wiring data fetching and store hooks at the organism boundary; keeping loading/error/empty states at this layer (not in molecules); defining responsive breakpoint behaviour per feature.
+description: Atomic-design guidance for Organisms — complex feature-level sections (Header, ProductGrid, CommentSection) that compose molecules, render loading/error/empty states from props, and own responsive layout decisions. Organisms stay presentational; a Container connects them to state and passes data/events down. Use when authoring components under ui/organisms or deciding molecule vs organism boundaries.
+when_to_use: Creating or reviewing organism-level components; keeping organisms presentational (data and event callbacks arrive as props from a Container, not from store hooks inside the organism); keeping loading/error/empty rendering at this layer (not in molecules); defining responsive breakpoint behaviour per feature.
 paths:
   - "**/ui/organisms/**/*.{jsx,tsx,vue,js,ts}"
   - "**/components/organisms/**/*"
@@ -12,27 +12,29 @@ paths:
 
 ## What is an Organism?
 
-Organisms are complex, self-contained UI sections composed of molecules and atoms—headers, product grids, comment sections. They often connect to state, handle business logic, and represent features users recognize by name.
+Organisms are complex, self-contained UI sections composed of molecules and atoms—headers, product grids, comment sections. They represent features users recognize by name and render the feature's loading/error/empty states. Crucially, they stay **presentational**: their data and event callbacks arrive as props from a Container, which is what actually connects to state.
 
 ## Key Principles
 
-1. **Feature Encapsulation**: Organisms encapsulate entire features (ProductGrid, CommentSection, NavigationBar). They're the boundary between presentational and container logic.
+1. **Feature Encapsulation**: Organisms encapsulate entire features (ProductGrid, CommentSection, NavigationBar). They're the presentational half of the boundary with container logic.
 
-2. **State Connection Point**: Organisms are where you connect to stores, make API calls, and handle business logic. Keep atoms/molecules pure.
+2. **Connected via a Container, not directly**: Organisms do **not** subscribe to the store, fetch data, or call APIs themselves. A Container (see the Container skill) connects to state, performs the side effects, and passes `data` + `events` props down. The organism receives those props and renders—keep atoms, molecules, and organisms pure.
 
 3. **Responsive Orchestration**: Organisms handle responsive layout changes (mobile hamburger vs desktop nav) while child components remain unchanged.
 
 ## Best Practices
 
 ✅ **DO**:
-- Connect to state management (Redux, Vuex, Pinia)
-- Handle data fetching and loading states
+- Receive feature data and event callbacks as props from a Container
+- Render loading, error, and empty states from those props
 - Compose molecules and atoms for complex UI
-- Implement feature-specific business logic
+- Keep feature-specific presentation logic (conditional layout, formatting)
 - Define responsive breakpoint behaviors
 - Handle error states and edge cases
 
 ❌ **DON'T**:
+- Connect to the store, fetch data, or call APIs directly here (that's the Container's job)
+- Put business logic here (it belongs in state/containers)
 - Put layout concerns here (that's templates)
 - Make organisms too large—split into sub-organisms
 - Duplicate logic across similar organisms
@@ -43,62 +45,76 @@ Organisms are complex, self-contained UI sections composed of molecules and atom
 
 ### Recommended
 
+The organism is presentational; a **Container** connects it to state and passes `data` + `events` props.
+
 ```jsx
-// ProductGrid.jsx - Organism with state connection
-import { useProducts } from '../hooks/useProducts';
-import ProductCard from '../molecules/ProductCard';
-import FilterBar from '../molecules/FilterBar';
-import LoadingSpinner from '../atoms/LoadingSpinner';
+// ui/organisms/ProductGrid/ProductGrid.component.jsx — presentational organism
+import ProductCard from '../../molecules/ProductCard/ProductCard.component';
+import FilterBar from '../../molecules/FilterBar/FilterBar.component';
+import LoadingSpinner from '../../atoms/LoadingSpinner/LoadingSpinner.component';
+import EmptyState from '../../atoms/EmptyState/EmptyState.component';
+import ErrorMessage from '../../atoms/ErrorMessage/ErrorMessage.component';
 
-const ProductGrid = ({ category }) => {
-  const [filters, setFilters] = useState({ sortBy: 'popular' });
-  const { products, loading, error } = useProducts({ category, ...filters });
-
-  if (loading) return <LoadingSpinner />;
-  if (error) return <ErrorMessage message={error} />;
-  if (!products.length) return <EmptyState />;
+export default function ProductGrid({ productData, events }) {
+  if (productData.error) return <ErrorMessage message={productData.error} />;
+  if (productData.isLoading) return <LoadingSpinner />;
+  if (!productData.products.length) return <EmptyState />;
 
   return (
     <section className="product-grid">
-      <FilterBar filters={filters} onChange={setFilters} />
+      <FilterBar filters={productData.filters} onChange={events.onFilterChange} />
       <div className="product-grid__items">
-        {products.map(product => (
+        {productData.products.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}
       </div>
     </section>
   );
-};
+}
+```
+
+```jsx
+// containers/ProductGridContainer.jsx — Container: connects state to the organism
+import useStore from '../state'; // or react-redux useSelector/useDispatch, etc.
+import ProductGrid from '../ui/organisms/ProductGrid/ProductGrid.component';
+
+export default function ProductGridContainer() {
+  const productData = useStore((state) => state.products);
+  const setFilter = useStore((state) => state.setFilter);
+
+  const events = { onFilterChange: (filters) => setFilter(filters) };
+
+  return <ProductGrid productData={productData} events={events} />;
+}
 ```
 
 ### Avoid
 
 ```jsx
-// ❌ WRONG - Organism with no state handling
-const ProductGrid = ({ products }) => (
-  <div>{products.map(p => <ProductCard product={p} />)}</div>
-);
-// This is a molecule, not an organism!
+// ❌ WRONG - Organism reaching into the store / fetching directly
+import { useProducts } from '../hooks/useProducts';
 
-// ✅ CORRECT - Organism handles its own data
-const ProductGrid = ({ categoryId }) => {
-  const { products, loading } = useProducts(categoryId);
-  // Full feature encapsulation
+const ProductGrid = ({ category }) => {
+  const { products, loading } = useProducts(category); // organism now coupled to state
+  useEffect(() => { /* fetch on mount */ }, []);
+  return <div>{products.map((p) => <ProductCard product={p} />)}</div>;
 };
+// Move the store/fetch wiring into a Container and pass data + events as props.
+// A pure props-driven organism is correct — it is NOT "just a molecule".
 ```
 
 ## Related Terminologies
 
 - **Molecule** (UI) - Simpler components organisms compose
 - **Template** (UI) - Page layouts that arrange organisms
-- **Container** (Server) - Similar concept for data connection
-- **Store** (State) - Where organisms get their data
+- **Container** (Server) - Connects state to the organism and passes data/events as props
+- **Store** (State) - Where the Container (not the organism) reads data from
 
 ## Quality Gates
 
 - [ ] Represents a recognizable feature
-- [ ] Handles loading, error, empty states
-- [ ] Connects to state management appropriately
+- [ ] Renders loading, error, empty states from props
+- [ ] Stays presentational — connected to state through a Container, not directly
 - [ ] Composes molecules/atoms (doesn't recreate)
 - [ ] Responsive behavior defined
 - [ ] Single feature focus

--- a/skills/ui-theme/README.md
+++ b/skills/ui-theme/README.md
@@ -4,11 +4,11 @@
 
 > `ui-theme` — an [Agent Skill](https://agentskills.io) from [elegant](../../README.md).
 
-Design-token systems — semantic CSS custom properties for colours, spacing, typography, and shadows, with light/dark theme switching via `[data-theme]` overrides. Use when setting up a token catalogue, auditing components for hardcoded colours/magic numbers, or adding dark-mode support via token swaps.
+Design-token systems — semantic CSS custom properties for colours, spacing, typography, and shadows, with light/dark theme switching via a `body.dark` class override. Use when setting up a token catalogue, auditing components for hardcoded colours/magic numbers, or adding dark-mode support via token swaps.
 
 ## When to use
 
-Setting up or extending a design-token catalogue; replacing hardcoded colours/spacing with `var(--token)` references; implementing dark-mode via `[data-theme="dark"]` overrides; enforcing semantic names (--color-error) over value names (--color-red).
+Setting up or extending a design-token catalogue; replacing hardcoded colours/spacing with `var(--token)` references; implementing dark-mode via a `body.dark` class override; enforcing semantic names (--color-error) over value names (--color-red).
 
 ## Install
 

--- a/skills/ui-theme/SKILL.md
+++ b/skills/ui-theme/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-theme
-description: Design-token systems — semantic CSS custom properties for colours, spacing, typography, and shadows, with light/dark theme switching via `[data-theme]` overrides. Use when setting up a token catalogue, auditing components for hardcoded colours/magic numbers, or adding dark-mode support via token swaps.
-when_to_use: Setting up or extending a design-token catalogue; replacing hardcoded colours/spacing with `var(--token)` references; implementing dark-mode via `[data-theme="dark"]` overrides; enforcing semantic names (--color-error) over value names (--color-red).
+description: Design-token systems — semantic CSS custom properties for colours, spacing, typography, and shadows, with light/dark theme switching via a `body.dark` class override. Use when setting up a token catalogue, auditing components for hardcoded colours/magic numbers, or adding dark-mode support via token swaps.
+when_to_use: Setting up or extending a design-token catalogue; replacing hardcoded colours/spacing with `var(--token)` references; implementing dark-mode via a `body.dark` class override; enforcing semantic names (--color-error) over value names (--color-red).
 paths:
   - "**/theme/**/*.{css,scss,less}"
   - "**/styles/**/*.{css,scss,less}"
@@ -73,8 +73,8 @@ Themes are systematic design languages implemented through CSS—design tokens c
   --font-size-lg: 1.25rem;
 }
 
-/* Dark mode via token override */
-[data-theme="dark"] {
+/* Dark mode via token override (toggle a `dark` class on <body>) */
+body.dark {
   --color-surface: #0f172a;
   --color-text: #f1f5f9;
 }


### PR DESCRIPTION
## Summary

Audited all 35 skills against how the **templates actually implement** the architecture and corrected the statements that contradicted the code. The recurring bug was UI/state skills describing connections and conventions that the templates don't use (the `ui-organism` "connects to state directly" issue was the first instance — this PR sweeps the rest).

The guiding ground truth: UI under `src/ui/**` is **purely presentational** (props in, events out); **containers** connect state and pass `data` + `events` down (`state → container → organism`); the templates are client-side SPAs; the shared async pattern is the **request/success/error** triple (`*_ERROR`, not `*_FAILURE`).

## Corrections

| Skill | Was | Now |
|---|---|---|
| **ui-organism** | organisms connect to the store; a props-only organism is "just a molecule" | presentational; a Container connects them (`TodoList` ← `TodoListContainer`) |
| **ui-atomic-design** | organisms "may connect to state" | "stay presentational (a container connects them to state)" |
| **ui-theme** | dark mode via `[data-theme="dark"]` | via a `body.dark` class (matches `theme.css` + `ConfigContainer`) |
| **server-container** | spread individual props/callbacks; `jest.fn()` | real `data` + `events` → presentational organism; Zustand variant; `vi.fn()`; side-effect-only `ConfigContainer` |
| **server-page** | a Next.js data-fetching layer | SPA route-level composition of containers in a layout; Next.js hooks marked as general guidance |
| **state-actions** | request/success/**failure** | request/success/**error** |
| **state-crud** | `*_FAILURE` constants; "RTK createAsyncThunks for all four ops" | `*_ERROR` constants; "async thunks or sagas" |
| **state-selectors** | Reselect/`createSelector` + `selectXxx` as *the* pattern | plain colocated selectors; Reselect/memoisation **optional** |

Every frontmatter `description`/`when_to_use` change is mirrored into the skill's `README.md`.

## Scope notes

- Skills that are general or forward-looking guidance with **no contradicting template code** were intentionally left unchanged — most `server-*` (router, ssr, ssg, app-shell, api, authentication, proxy, protocol, mfe) and the lower-level `ui-*` skills (element, dom, events, attributes, props, accessibility, story) and `state-*` (state, store, reducer, middleware, operations, ajax). Edits were minimal and correctness-only, not stylistic.
- The published doc `docs/ui/organism.md` has the same original organism error; it's **not** touched here because docs under `docs/{ui,server,state}/` have a separate `doc-reviewer` process per `CLAUDE.md`. Happy to do that as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD)_