### PR TITLE
docs(state skills): Zustand coverage + src/state/** path matching

### DIFF
--- a/skills/state-actions/SKILL.md
+++ b/skills/state-actions/SKILL.md
@@ -3,6 +3,7 @@ name: state-actions
 description: Redux/NgRx/RTK action design — plain-object events describing what happened, FSA-compliant structure, and request/success/error patterns for async flows. Use when writing action creators, RTK slices, or reviewing action-type naming and payload shape.
 when_to_use: Authoring or reviewing action creators, type constants, or RTK slice reducers; designing async action triples (request/success/error); enforcing FSA compliance and serialisable payloads.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/actions/**/*.{js,ts}"
   - "**/*Actions*.{js,ts}"

--- a/skills/state-actions/SKILL.md
+++ b/skills/state-actions/SKILL.md
@@ -167,6 +167,15 @@ function TodoForm() {
 }
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+Zustand keeps no separate action creators or type constants — actions are functions on the store that call `set()`. The request/success/error triple collapses into one async action (optimistic `set` → await API → confirm or roll back). The 3rd argument to `set` is the DevTools action label, so traces still read like Redux:
+
+```js
+updateConfig: (payload) =>
+  set((state) => ({ config: { ...state.config, ...payload } }), false, 'config/updateConfig'),
+```
+
 ## Related Terminologies
 
 - **Reducer** (State) - Handles actions to update state

--- a/skills/state-ajax/SKILL.md
+++ b/skills/state-ajax/SKILL.md
@@ -182,6 +182,22 @@ source.cancel('Cancelled');
 | Timeout | Manual | Built-in |
 | Cancel | AbortController | CancelToken |
 
+## In the Zustand template (`chota-react-zustand`)
+
+Zustand needs no thunk/saga middleware for data fetching — an async store action awaits the fetch-style `utils/api` directly and `set`s loading/success/error as it goes:
+
+```js
+readTodo: async () => {
+  get().setTodo({ isContentLoading: true });
+  try {
+    const res = await getTodoApi();
+    get().setTodo({ isContentLoading: false, todoItems: await res.json() });
+  } catch (e) {
+    get().setTodo({ isContentLoading: false, error: e.toString() });
+  }
+},
+```
+
 ## Related Terminologies
 
 - **API** (Server) - Service layer abstraction

--- a/skills/state-ajax/SKILL.md
+++ b/skills/state-ajax/SKILL.md
@@ -3,6 +3,7 @@ name: state-ajax
 description: Async data-fetching patterns — Fetch vs Axios, service-layer organisation, AbortController cancellation, and integration with Redux Toolkit's createAsyncThunk for pending/fulfilled/rejected state transitions. Use when writing or reviewing HTTP call sites, standardising loading/error handling, or wiring request cancellation in effects.
 when_to_use: Choosing between fetch and axios; setting up an apiClient with interceptors; integrating async requests with Redux/NgRx slices; cancelling in-flight requests on unmount via AbortController; handling loading/error/success state uniformly.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/api/**/*.{js,ts}"
   - "**/services/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"

--- a/skills/state-crud/README.md
+++ b/skills/state-crud/README.md
@@ -8,7 +8,7 @@ CRUD patterns for state slices — consistent `domain/create|read|update|delete`
 
 ## When to use
 
-Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks or sagas for all four CRUD ops.
+Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks, sagas, or Zustand store actions for all four CRUD ops.
 
 ## Install
 

--- a/skills/state-crud/SKILL.md
+++ b/skills/state-crud/SKILL.md
@@ -3,6 +3,7 @@ name: state-crud
 description: CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/error triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
 when_to_use: Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks, sagas, or Zustand store actions for all four CRUD ops.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/slices/**/*.{js,ts}"
   - "**/*Actions*.{js,ts}"

--- a/skills/state-crud/SKILL.md
+++ b/skills/state-crud/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: state-crud
 description: CRUD patterns for state slices — consistent `domain/create|read|update|delete` action naming, request/success/error triples per operation, and normalised `{ byId, allIds }` entity shapes for O(1) lookups. Use when designing a new entity slice, standardising action-type names, or refactoring array-shaped state.
-when_to_use: Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks or sagas for all four CRUD ops.
+when_to_use: Designing a new entity slice (todos, users, products); standardising request/success/error naming across async operations; normalising state from arrays to byId/allIds; wiring async thunks, sagas, or Zustand store actions for all four CRUD ops.
 paths:
   - "**/store/**/*.{js,ts}"
   - "**/slices/**/*.{js,ts}"
@@ -184,6 +184,10 @@ function TodoManager() {
   ]
 }
 ```
+
+## In the Zustand template (`chota-react-zustand`)
+
+`chota-react-zustand` implements all four CRUD operations as async store actions (`createTodo` / `readTodo` / `updateTodo` / `deleteTodo`) on a per-domain slice — each does the optimistic `set`, awaits `utils/api`, then confirms or rolls back. Same request/success/error semantics as the Redux-saga template, without action-type constants.
 
 ## Related Terminologies
 

--- a/skills/state-middleware/SKILL.md
+++ b/skills/state-middleware/SKILL.md
@@ -167,6 +167,10 @@ dispatch(action)
 reducer → updates state
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+Zustand's middleware wraps the store *creator* rather than the dispatch pipeline. `chota-react-zustand` uses the built-in `devtools` middleware — `create(devtools(fn, { name: 'elegant-zustand' }))` — to get Redux DevTools traces (the action name is the 3rd argument to `set`). `persist`, `immer`, and `subscribeWithSelector` compose the same way by nesting the wrappers.
+
 ## Related Terminologies
 
 - **Actions** (State) - Flow through middleware

--- a/skills/state-middleware/SKILL.md
+++ b/skills/state-middleware/SKILL.md
@@ -3,6 +3,7 @@ name: state-middleware
 description: Redux middleware — the `store => next => action => {}` pipeline for side effects, logging, analytics, and async (thunk/saga). Use when writing custom middleware, wiring async thunks, ordering middleware in configureStore, or keeping side effects out of reducers.
 when_to_use: Adding logger/analytics/crash-reporting middleware; writing a custom thunk-style middleware; ordering middleware in configureStore (logger last); moving side effects out of reducers.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/middleware/**/*.{js,ts}"
   - "**/*Middleware*.{js,ts}"

--- a/skills/state-operations/SKILL.md
+++ b/skills/state-operations/SKILL.md
@@ -3,6 +3,7 @@ name: state-operations
 description: Async operation patterns — explicit idle/loading/succeeded/failed status tracking, optimistic updates with rollback, debouncing/batching, and race-condition handling via request cancellation. Use when designing async workflows, wiring createAsyncThunk pending/fulfilled/rejected handlers, or fixing stale-data bugs from out-of-order responses.
 when_to_use: Tracking loading/success/error per operation; implementing optimistic UI with rollback on failure; debouncing search/autosave; cancelling stale requests to avoid race conditions; showing skeleton/error/empty states uniformly.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/operations/**/*.{js,ts}"
   - "**/*thunk*.{js,ts}"

--- a/skills/state-operations/SKILL.md
+++ b/skills/state-operations/SKILL.md
@@ -182,6 +182,10 @@ function TodoList() {
 }
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+The Zustand template runs the same idle → loading → succeeded/failed flow with optimistic updates and rollback, but inside a single async store action: it `set`s the optimistic state, awaits `utils/api`, then confirms on success or (on failure) waits `500ms` and restores the `previousStateTodoItems` snapshot it saved. It is the saga request/success/error operation collapsed into one function — no watcher, no effect middleware.
+
 ## Related Terminologies
 
 - **Ajax** (State) - HTTP requests in operations

--- a/skills/state-reducer/SKILL.md
+++ b/skills/state-reducer/SKILL.md
@@ -3,6 +3,7 @@ name: state-reducer
 description: Reducer design — pure `(state, action) => newState` functions, immutable updates (spread or Immer), default-case handling, and combineReducers composition. Use when writing or reviewing slice reducers, fixing accidental mutations, or splitting a monolithic reducer by domain.
 when_to_use: Writing new reducers or RTK slices; auditing for accidental state mutation or impure operations (Date.now, fetch) inside reducers; composing reducers with combineReducers; testing reducer cases in isolation.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/reducers/**/*.{js,ts}"
   - "**/*Reducer*.{js,ts}"

--- a/skills/state-reducer/SKILL.md
+++ b/skills/state-reducer/SKILL.md
@@ -182,6 +182,17 @@ describe('todosReducer', () => {
 });
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+Zustand has no reducer or `switch`. Each slice action updates state with an immutable `set((state) => ({ ... }))` updater — the same "return new state, never mutate" rule as a reducer, colocated with the action instead of keyed by action type:
+
+```js
+setVisibilityFilter: (filter) =>
+  set((state) => ({
+    filters: state.filters.map((f) => ({ ...f, selected: f.id === filter })),
+  }), false, 'filters/setVisibilityFilter'),
+```
+
 ## Related Terminologies
 
 - **Actions** (State) - Trigger reducer execution

--- a/skills/state-selectors/SKILL.md
+++ b/skills/state-selectors/SKILL.md
@@ -162,6 +162,16 @@ function TodoList() {
 }
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+Because selectors are plain functions of state, the elegant templates reuse the **same** ones across Redux and Zustand. `chota-react-zustand` keeps the identical `state.todo/filters/config` shape and calls the same `getVisibleTodos`/`getSelectedFilter` selectors through the `useStore` hook — no rewrite:
+
+```js
+const selectedFilter = useStore(getSelectedFilter);
+const todoState = useStore((s) => s.todo);
+const todoData = getVisibleTodos(todoState, selectedFilter.id);
+```
+
 ## Related Terminologies
 
 - **Store** (State) - Selectors read from store

--- a/skills/state-selectors/SKILL.md
+++ b/skills/state-selectors/SKILL.md
@@ -3,6 +3,7 @@ name: state-selectors
 description: Selector functions for reading state — plain selector functions colocated with slices, optional Reselect/createSelector memoisation, input-selector composition, and parameterised selector factories. Use when extracting state into components, avoiding redundant re-renders from filtered lists, or abstracting state shape behind selector helpers.
 when_to_use: Writing selector helpers colocated with slices; deriving data (filtered/sorted lists, aggregated stats), optionally memoising with createSelector; factoring parameterised selectors; replacing raw `state.x.y` access in components.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/selectors/**/*.{js,ts}"
   - "**/*Selectors*.{js,ts}"

--- a/skills/state-store/SKILL.md
+++ b/skills/state-store/SKILL.md
@@ -3,6 +3,7 @@ name: state-store
 description: Redux store architecture — configureStore setup, slice organisation by domain, normalised state shape, Provider wiring, typed hooks (useAppDispatch/useAppSelector), and DevTools. Use when scaffolding a new Redux store, splitting state into slices, or auditing state shape for normalisation and serialisability.
 when_to_use: Scaffolding a new configureStore; organising slices by domain; enforcing a single-store rule; shaping state as `{ byId, allIds }`; wiring `<Provider>` and typed hooks at the app root.
 paths:
+  - "**/state/**/*.{js,ts}"
   - "**/store/**/*.{js,ts}"
   - "**/redux/**/*.{js,ts}"
   - "**/*Store*.{js,ts}"

--- a/skills/state-store/SKILL.md
+++ b/skills/state-store/SKILL.md
@@ -145,6 +145,23 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 }
 ```
 
+## In the Zustand template (`chota-react-zustand`)
+
+Zustand is a single store too — but with no `<Provider>`, no dispatch, and no reducer. `create()` wraps a store creator, per-domain slices `(set, get) => ({ ... })` are merged in a `rootStore` (the `combineReducers` analogue), and components read it with the `useStore` hook. State stays namespaced (`todo`, `filters`, `config`) so the same selectors work as in the Redux templates.
+
+```js
+// state/index.js
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import createRootSlice from './rootStore';
+
+export const createAppStore = (preloadedState = {}) =>
+  create(devtools((set, get, api) => ({ ...createRootSlice(set, get, api) }), { name: 'elegant-zustand' }));
+
+const useStore = createAppStore(); // usage: useStore((s) => s.todo.todoItems)
+export default useStore;
+```
+
 ## Related Terminologies
 
 - **Actions** (State) - Events that trigger state changes


### PR DESCRIPTION
## Summary

Two focused improvements to the **state-\*** skills so they reflect the `chota-react-zustand` template and the elegant `src/state/**` layout.

### 1. Cover the Zustand template
Zustand shipped as `chota-react-zustand`, but only `state-state` mentioned it — the other 8 state skills were entirely Redux/RTK/NgRx/Pinia framed. Added a concise **"In the Zustand template (`chota-react-zustand`)"** section to each, mapping the concept to the real code:

| Skill | Zustand mapping |
|---|---|
| state-store | `create()` + `devtools`; slices merged in `rootStore` (the `combineReducers` analogue); `useStore` hook; `createAppStore` factory |
| state-actions | actions are store methods calling `set()`; 3rd arg = DevTools label; triple collapses into one async action |
| state-reducer | `set((state) => ({...}))` immutable updaters replace the reducer/`switch` |
| state-selectors | the *same* `getVisibleTodos`/`getSelectedFilter` selectors reused via `useStore` — no rewrite |
| state-middleware | `devtools`/`persist`/`immer` wrap the store *creator* |
| state-operations | optimistic update + 500 ms rollback inside one async store action |
| state-ajax | async store action awaits `utils/api` directly, no thunk middleware |
| state-crud | C/R/U/D as async store actions; frontmatter broadened to "thunks, sagas, or Zustand store actions" (+ README) |

Every snippet is lifted from the actual template (`config.slice.js`, `filters.slice.js`, `todo.slice.js`, `index.js`, `TodoListContainer.jsx`); code fences verified balanced.

### 2. Match the templates' `src/state/**` layout
Added `**/state/**/*.{js,ts}` as the first `paths` glob to the 8 state skills that lacked it (`state-state` already had it). The elegant templates keep slices/actions/reducers/selectors/operations/store under `src/state/`, but the skills only matched `store/`, `slices/`, `actions/`, etc. — so they wouldn't auto-activate there. Existing conventional globs are kept alongside for non-elegant codebases.

## Notes
- Follows the merged #46 (terminology re-evaluation); this is the Zustand/paths follow-up.
- `state-state` already treated Zustand as a peer, so it only gained the new path glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENb9j88DC9xbRt4BtHg5zD)_